### PR TITLE
ikvmc: Fix for compiling multi-release JARs in Java 8

### DIFF
--- a/src/ikvmc.Tests/IkvmcCompilerTests.cs
+++ b/src/ikvmc.Tests/IkvmcCompilerTests.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ikvmc.Tests
+{
+    [TestClass]
+    public class IkvmcCompilerTests
+    {
+        [TestMethod]
+        [DataRow(@"META-INF/foo/bar/baz.class", true)]
+        [DataRow(@"META-INF/Person.class", true)]
+        [DataRow(@"META-INF/versions/9/Person.class", true)]
+        [DataRow(@"META-INF\foo\bar\baz.class", false)]
+        [DataRow(@"meta-inf/foo/bar/baz.class", false)]
+        [DataRow(@"org/mycompany/myapp/test.class", false)]
+        [DataRow(@"module-info.class", false)]
+        [DataRow(@"META-INF/versions/9/module-info.class", true)]
+        public void Can_detect_META_INF_class_file(string name, bool expected)
+        {
+            IkvmcCompiler.IsMetaInfClassFile(name).Should().Be(expected);
+        }
+
+        [TestMethod]
+        [DataRow(@"META-INF/foo/bar/baz.class", false, default(int))]
+        [DataRow(@"META-INF/Person.class", false, default(int))]
+        [DataRow(@"META-INF/versions/9/Person.class", true, 9)]
+        [DataRow(@"META-INF\foo\bar\baz.class", false, default(int))]
+        [DataRow(@"meta-inf/foo/bar/baz.class", false, default(int))]
+        [DataRow(@"org/mycompany/myapp/test.class", false, default(int))]
+        [DataRow(@"module-info.class", false, default(int))]
+        [DataRow(@"META-INF/versions/9/module-info.class", true, 9)]
+        [DataRow(@"META-INF/versions/17/org/arg/app/SomeClass.class", true, 17)]
+        [DataRow(@"META-INF/versions/17a/org/arg/app/SomeClass.class", false, default(int))]
+        [DataRow(@"META-INF/versions/17.5/org/arg/app/SomeClass.class", false, default(int))]
+        public void Can_detect_multi_release_class_file_and_version(string name, bool expected, int expectedVersion)
+        {
+            IkvmcCompiler.IsMultiReleaseClassFile(name, out int actualVersion).Should().Be(expected);
+            actualVersion.Should().Be(expectedVersion);
+        }
+    }
+}

--- a/src/ikvmc/IkvmcCompiler.cs
+++ b/src/ikvmc/IkvmcCompiler.cs
@@ -1219,7 +1219,7 @@ namespace ikvmc
             return false;
         }
 
-        private static bool IsMultiModuleClassFile(CompilerOptions options, ZipEntry ze, out int majorVersion)
+        private static bool IsMultiReleaseClassFile(CompilerOptions options, ZipEntry ze, out int majorVersion)
         {
             int nextSlashIndex;
             string name = ze.Name;
@@ -1282,7 +1282,7 @@ namespace ikvmc
                             // or we can use it as a filter for major version. It is in place to mimic Java SE 8 tools, which ignore
                             // .class files in the META-INF/versions folder. This must be run before IsExcludedOrStubLegacy(), since
                             // that method expects Java SE 8 format and if we don't have it it fails to properly exclude stuff.
-                            if (IsMultiModuleClassFile(options, ze, out _))
+                            if (IsMultiReleaseClassFile(options, ze, out _))
                             {
                                 continue;
                             }

--- a/src/ikvmc/ikvmc.csproj
+++ b/src/ikvmc/ikvmc.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="IKVM.Java" />
+        <InternalsVisibleTo Include="ikvmc.Tests" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Ignore multi-release versioned .class files if they are present in the META-INF/versions folder, as was the case in Java SE 8 tools.

This fixes the issue described in https://github.com/ikvm-revived/ikvm-maven/issues/17.