### PR TITLE
ikvmc: fix -D flags unbalanced stack height crash

### DIFF
--- a/src/IKVM.Tools.Importer/CompilerClassLoader.cs
+++ b/src/IKVM.Tools.Importer/CompilerClassLoader.cs
@@ -517,7 +517,8 @@ namespace IKVM.Tools.Importer
                     if (kvp.Value.IndexOf('%') < kvp.Value.LastIndexOf('%'))
                         ilgen.Emit(OpCodes.Call, JVM.Import(typeof(Environment)).GetMethod(nameof(Environment.ExpandEnvironmentVariables), new[] { Types.String }));
 
-                    ilgen.Emit(OpCodes.Callvirt, propertiesType.GetMethod("setProperty", new Type[] { Types.Object, Types.Object }));
+                    ilgen.Emit(OpCodes.Callvirt, propertiesType.GetMethod("setProperty", new Type[] { Types.String, Types.String }));
+                    ilgen.Emit(OpCodes.Pop); // setProperty returns previous value
                 }
             }
 


### PR DESCRIPTION
This was working in 8.1.

I'm not familiar with testing system. a test could be simple `ikvmc.exe -Da=b a.class` call.