### PR TITLE
ikvmc.csproj: missing reference to runtime

### DIFF
--- a/src/ikvmc/ikvmc.csproj
+++ b/src/ikvmc/ikvmc.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)..\..\IKVM.deps.props" />
-    
+    <Import Project="$(MSBuildThisFileDirectory)..\..\IKVM.refs.props" />
+
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>


### PR DESCRIPTION
Without this VS does not put dlls near the exe and run command fails.