### PR TITLE
Let IKVM.Net.Sdk handle java archives as opaque ikvmc conversion target

### DIFF
--- a/src/IKVM.Java/IKVM.Java.msbuildproj
+++ b/src/IKVM.Java/IKVM.Java.msbuildproj
@@ -44,7 +44,7 @@
         <None Include="local\**\*" />
         <None Include="@(OpenJdkSource)" LinkBase="openjdk\%(PackagePath)" />
         <Compile Include="@(OpenJdkSource)" LinkBase="openjdk\%(PackagePath)" />
-        <Class Include="@(OpenJdkClass)" LinkBase="openjdk\%(PackagePath)" />
+        <Convert Include="@(OpenJdkClass)" LinkBase="openjdk\%(PackagePath)" />
         <None Include="@(OpenJdkClass)" LinkBase="openjdk\%(PackagePath)" />
         <JavaResource Include="@(OpenJdkResource)" LinkBase="openjdk\%(PackagePath)" />
         <ExcludeRegex Include="@(OpenJdkExcludeRegex)" />
@@ -127,7 +127,7 @@
 
     <Target Name="BuildRmiStubs" DependsOnTargets="$(BuildRmiStubsDependsOn)">
         <ItemGroup>
-            <Class Include="$(RmiStubsOutputPath)**\*.class" />
+            <Convert Include="$(RmiStubsOutputPath)**\*.class" />
         </ItemGroup>
     </Target>
 

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.NoTasks.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.NoTasks.targets
@@ -158,10 +158,10 @@ Items = Items.OrderBy(i => i.ItemSpec).ToArray();
         <WriteLinesToFile File="$(_ExcludeFilePath)" Lines="@(ExcludeRegex)" Overwrite="true" Condition=" '@(ExcludeRegex)' != '' " WriteOnlyWhenDifferent="true" />
 
         <ItemGroup>
-            <_ClassToCompile Include="@(Class)" />
-            <_AssemblyAttributesClass Include="@(_ClassToCompile)" Condition=" '%(Filename)%(Extension)' == '__AssemblyAttributes.class' " />
-            <_AssemblyAttributesClass Include="@(_ClassToCompile)" Condition=" '%(Filename)%(Extension)' == '__AssemblyInfo.class' " />
-            <_ClassToCompile Remove="@(_AssemblyAttributesClass)" />
+            <_Convert Include="@(Convert)" />
+            <_AssemblyAttributesClass Include="@(_Convert)" Condition=" '%(Filename)%(Extension)' == '__AssemblyAttributes.class' " />
+            <_AssemblyAttributesClass Include="@(_Convert)" Condition=" '%(Filename)%(Extension)' == '__AssemblyInfo.class' " />
+            <_Convert Remove="@(_AssemblyAttributesClass)" />
         </ItemGroup>
 
         <PropertyGroup>
@@ -173,8 +173,8 @@ Items = Items.OrderBy(i => i.ItemSpec).ToArray();
             <Output TaskParameter="Items" ItemName="_IkvmCompilerJavaResource" />
         </IkvmSortItemGroup>
 
-        <IkvmSortItemGroup Items="@(_ClassToCompile)">
-            <Output TaskParameter="Items" ItemName="_IkvmCompilerClassToCompile" />
+        <IkvmSortItemGroup Items="@(_Convert)">
+            <Output TaskParameter="Items" ItemName="_IkvmCompilerConvert" />
         </IkvmSortItemGroup>
 
         <IkvmSortItemGroup Items="@(ReferencePathWithRefAssemblies)">
@@ -210,7 +210,7 @@ Items = Items.OrderBy(i => i.ItemSpec).ToArray();
             <_IkvmCompilerResourceItem Include="@(_IkvmCompilerJavaResource)" ResourcePath="$([System.String]::new('%(_IkvmCompilerJavaResource.ResourcePath)').Replace('\', '/'))" Condition=" '%(Identity)' != '' " />
             <_IkvmCompilerArgs Include="@(_IkvmCompilerResourceItem->'-resource:%(ResourcePath)=%(FullPath)')" />
             <_IkvmCompilerArgs Include="-out:$(_AssemblyTempPath)$(TargetName)$(TargetExt)" />
-            <_IkvmCompilerArgs Include="@(_IkvmCompilerClassToCompile->'%(FullPath)')" />
+            <_IkvmCompilerArgs Include="@(_IkvmCompilerConvert->'%(FullPath)')" />
         </ItemGroup>
         <WriteLinesToFile File="$(_IkvmCompilerResponseFile)" Lines="@(_IkvmCompilerArgs)" Overwrite="true" WriteOnlyWhenDifferent="true" />
     </Target>
@@ -222,7 +222,7 @@ Items = Items.OrderBy(i => i.ItemSpec).ToArray();
         </CoreCompileDependsOn>
     </PropertyGroup>
 
-    <Target Name="_CoreCompile" DependsOnTargets="_CoreCompileResponseFile" Inputs="$(_IkvmCompilerResponseFile);$(_ExcludeFilePath);$(IkvmRuntimeAssembly);$(KeyOriginatorFile);@(MapFile);@(ReferencePathWithRefAssemblies);@(Class);@(JavaResource);$(_CompileJavaStampFile)" Outputs="@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)">
+    <Target Name="_CoreCompile" DependsOnTargets="_CoreCompileResponseFile" Inputs="$(_IkvmCompilerResponseFile);$(_ExcludeFilePath);$(IkvmRuntimeAssembly);$(KeyOriginatorFile);@(MapFile);@(ReferencePathWithRefAssemblies);@(Convert);@(JavaResource);$(_CompileJavaStampFile)" Outputs="@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)">
         <!-- Build Java assembly into temporary directory. -->
         <RemoveDir Directories="$(_AssemblyTempPath)" Condition="Exists('$(_AssemblyTempPath)')" />
         <MakeDir Directories="$(_AssemblyTempPath)" />

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.Tasks.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.Tasks.targets
@@ -80,7 +80,7 @@
     </Target>
 
     <!-- Override IKVM.NET.Sdk: invoke compiler through task  -->
-    <Target Name="_CoreCompile" DependsOnTargets="ResolveIkvmRuntimeAssembly;CompileJava" Inputs="$(IkvmRuntimeAssembly);$(KeyOriginatorFile);@(MapFile);@(ReferencePathWithRefAssemblies);@(Class);@(JavaResource);$(_CompileJavaStampFile)" Outputs="@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)">
+    <Target Name="_CoreCompile" DependsOnTargets="ResolveIkvmRuntimeAssembly;CompileJava" Inputs="$(IkvmRuntimeAssembly);$(KeyOriginatorFile);@(MapFile);@(ReferencePathWithRefAssemblies);@(Convert);@(JavaResource);$(_CompileJavaStampFile)" Outputs="@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)">
         <Error Text="IKVM.NET.Sdk cannot currently build assemblies targeting '$(TargetFramework)'. Either target 'net461' or 'netcoreapp3.1'." Condition=" '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'netcoreapp3.1' " />
         <Error Text="Could not locate IKVM.Runtime assembly." Condition=" '$(IkvmRuntimeAssembly)' == '' " />
         <Error Text="IKVM.Runtime.dll could not be located at '$(IkvmRuntimeAssembly)'." Condition="!Exists('$(IkvmRuntimeAssembly)')" />
@@ -89,10 +89,10 @@
         <WriteLinesToFile File="$(_ExcludeFilePath)" Lines="@(ExcludeRegex)" Overwrite="true" Condition=" '@(ExcludeRegex)' != '' " />
 
         <ItemGroup>
-            <_ClassToCompile Include="@(Class)" />
-            <_AssemblyAttributesClass Include="@(_ClassToCompile)" Condition=" '%(Filename)%(Extension)' == '__AssemblyAttributes.class' " />
-            <_AssemblyAttributesClass Include="@(_ClassToCompile)" Condition=" '%(Filename)%(Extension)' == '__AssemblyInfo.class' " />
-            <_ClassToCompile Remove="@(_AssemblyAttributesClass)" />
+            <_Convert Include="@(Convert)" />
+            <_AssemblyAttributesClass Include="@(_Convert)" Condition=" '%(Filename)%(Extension)' == '__AssemblyAttributes.class' " />
+            <_AssemblyAttributesClass Include="@(_Convert)" Condition=" '%(Filename)%(Extension)' == '__AssemblyInfo.class' " />
+            <_Convert Remove="@(_AssemblyAttributesClass)" />
             <_IkvmCompilerReferencePath Include="@(ReferencePathWithRefAssemblies)" Condition=" '%(ReferencePathWithRefAssemblies.HideFromJava)' != 'true' " />
             <_IkvmCompilerResource Include="@(JavaResource)" ResourcePath="$([System.String]::new('%(JavaResource.ResourcePath)').Replace('\', '/'))" Condition=" '%(Identity)' != '' " />
         </ItemGroup>
@@ -136,7 +136,7 @@
             RemoveAssertions="$(RemoveAssertions)"
             Resources="@(_IkvmCompilerResource)"
             Remap="@(MapFile)"
-            Input="@(_ClassToCompile)" />
+            Input="@(_Convert)" />
 
         <!-- Move temporary files in place of permanent files. -->
         <Move SourceFiles="$(_AssemblyTempPath)$(TargetName)$(TargetExt)" DestinationFiles="@(IntermediateAssembly)" OverwriteReadOnlyFiles="true" />

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
@@ -113,10 +113,6 @@ Files = files.ToArray();
         </ClasspathToClasspathFiles>
     </Target>
 
-    <ItemGroup>
-        <Compile Include="$(MSBuildThisFileDirectory)_.java" />
-    </ItemGroup>
-
     <!-- Abstract target to conduct actual Java compilation. Overridden either by Command or Task implementation. -->
     <Target Name="_CompileJava" DependsOnTargets="ExportReferences;_ResolveClasspathFiles" Inputs="@(Compile);@(ClasspathFiles)" Outputs="$(_CompileJavaStampFile)">
         <Error Text="_CompileJava not implemented." />

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
@@ -134,7 +134,7 @@ Files = files.ToArray();
 
     <Target Name="CompileJava" DependsOnTargets="$(CompileJavaDependsOn)">
         <ItemGroup>
-            <Class Include="$(ClassOutputPath)**\*.class" />
+            <Convert Include="$(ClassOutputPath)**\*.class" />
         </ItemGroup>
     </Target>
 
@@ -158,7 +158,7 @@ Files = files.ToArray();
     </PropertyGroup>
 
     <!-- Abstract target to conduct compilation. Overridden either by Command or Task implementation. -->
-    <Target Name="_CoreCompile" DependsOnTargets="CompileJava" Inputs="$(IkvmRuntimeAssembly);$(KeyOriginatorFile);@(MapFile);@(ReferencePathWithRefAssemblies);@(Class);@(JavaResource);$(_CompileJavaStampFile)" Outputs="@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)">
+    <Target Name="_CoreCompile" DependsOnTargets="CompileJava" Inputs="$(IkvmRuntimeAssembly);$(KeyOriginatorFile);@(MapFile);@(ReferencePathWithRefAssemblies);@(Convert);@(JavaResource);$(_CompileJavaStampFile)" Outputs="@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)">
         <Error Text="_CoreCompile not implemented." />
     </Target>
 

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
@@ -132,7 +132,7 @@ Files = files.ToArray();
         </CompileJavaDependsOn>
     </PropertyGroup>
 
-    <Target Name="CompileJava" DependsOnTargets="$(CompileJavaDependsOn)">
+    <Target Name="CompileJava" Inputs="@(Compile)" Outputs="@(Convert)" DependsOnTargets="$(CompileJavaDependsOn)">
         <ItemGroup>
             <Convert Include="$(ClassOutputPath)**\*.class" />
         </ItemGroup>

--- a/src/IKVM.NET.Sdk/targets/Java.ProjectItemsSchema.xaml
+++ b/src/IKVM.NET.Sdk/targets/Java.ProjectItemsSchema.xaml
@@ -9,12 +9,19 @@
     <ContentType
         Name="JavaClassFile"
         DisplayName="Java class file"
-        ItemType="Class">
+        ItemType="Convert">
+    </ContentType>
+
+    <ContentType
+        Name="JavaArchiveFile"
+        DisplayName="Java archive file"
+        ItemType="Convert">
     </ContentType>
 
     <ItemType Name="Compile" UpToDateCheckInput="true" DisplayName="Compile" />
-    <ItemType Name="Class" UpToDateCheckInput="true" DisplayName="Class" />
+    <ItemType Name="Convert" UpToDateCheckInput="true" DisplayName="Convert" />
 
+    <FileExtension Name=".jar" ContentType="JavaArchiveFile"/>
     <FileExtension Name=".java" ContentType="JavaSourceFile"/>
     <FileExtension Name=".class" ContentType="JavaClassFile"/>
 </ProjectSchemaDefinitions>


### PR DESCRIPTION
Tested in the wild (https://github.com/iterate-ch/cyberduck/compare/master...feature/winui).

IKVM builds fine (didn't see any regression).
A first converted application (CLI, as UI is somewhat complicated) is working without issue.

ProjectReference, Reference and type discovery works fine (no duplicate classes are generated).

Resolves #326