### PR TITLE
Enable .NET7 builds and tests

### DIFF
--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -302,7 +302,7 @@ jobs:
         exclude:
         - tfm: net461
           sys: linux
-        - run: IKVM.Tests.Java
+        - run: IKVM.Java.Tests
           tfm: net6.0
         - run: IKVM.Tools.Exporter.Tests
           tfm: net6.0
@@ -324,7 +324,7 @@ jobs:
           tfm: net6.0
         - run: IKVM.OpenJDK.Tests?TestPartition=7
           tfm: net6.0
-        - run: IKVM.Tests.Java
+        - run: IKVM.Java.Tests
           tfm: net7.0
         - run: IKVM.Tools.Exporter.Tests
           tfm: net7.0

--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -295,6 +295,7 @@ jobs:
         - net461
         - netcoreapp3.1
         - net6.0
+        - net7.0
         sys:
         - windows
         - linux
@@ -323,6 +324,28 @@ jobs:
           tfm: net6.0
         - run: IKVM.OpenJDK.Tests?TestPartition=7
           tfm: net6.0
+        - run: IKVM.Tests.Java
+          tfm: net7.0
+        - run: IKVM.Tools.Exporter.Tests
+          tfm: net7.0
+        - run: IKVM.Tools.Importer.Tests
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=0
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=1
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=2
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=3
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=4
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=5
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=6
+          tfm: net7.0
+        - run: IKVM.OpenJDK.Tests?TestPartition=7
+          tfm: net7.0
         include:
         - run: IKVM.MSBuild.Tasks.Tests
           tfm: net472
@@ -334,22 +357,28 @@ jobs:
           tfm: net6.0
           sys: windows
         - run: IKVM.MSBuild.Tasks.Tests
+          tfm: net7.0
+          sys: windows
+        - run: IKVM.MSBuild.Tasks.Tests
           tfm: netcoreapp3.1
           sys: linux
         - run: IKVM.MSBuild.Tasks.Tests
           tfm: net6.0
           sys: linux
+        - run: IKVM.MSBuild.Tasks.Tests
+          tfm: net7.0
+          sys: linux
         - run: IKVM.MSBuild.Tests
-          tfm: net6.0
+          tfm: net7.0
           sys: windows
         - run: IKVM.MSBuild.Tests
-          tfm: net6.0
+          tfm: net7.0
           sys: linux
         - run: IKVM.NET.Sdk.Tests
-          tfm: net6.0
+          tfm: net7.0
           sys: windows
         - run: IKVM.NET.Sdk.Tests
-          tfm: net6.0
+          tfm: net7.0
           sys: linux
     name: Test (${{ matrix.run }}:${{ matrix.tfm }}:${{ matrix.sys }})
     needs:

--- a/src/IKVM.ByteCode.Tests/IKVM.ByteCode.Tests.csproj
+++ b/src/IKVM.ByteCode.Tests/IKVM.ByteCode.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/src/IKVM.ByteCode/IKVM.ByteCode.csproj
+++ b/src/IKVM.ByteCode/IKVM.ByteCode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
         <LangVersion>11</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/IKVM.JTReg.TestAdapter.Tests/IKVM.JTReg.TestAdapter.Tests.csproj
+++ b/src/IKVM.JTReg.TestAdapter.Tests/IKVM.JTReg.TestAdapter.Tests.csproj
@@ -5,7 +5,7 @@
     <Import Project="$(MSBuildThisFileDirectory)..\..\jtreg.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
         <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 

--- a/src/IKVM.MSBuild.Tasks.Tests/IKVM.MSBuild.Tasks.Tests.csproj
+++ b/src/IKVM.MSBuild.Tasks.Tests/IKVM.MSBuild.Tasks.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/IKVM.MSBuild.Tests/IKVM.MSBuild.Tests.csproj
+++ b/src/IKVM.MSBuild.Tests/IKVM.MSBuild.Tests.csproj
@@ -2,7 +2,7 @@
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net7.0</TargetFrameworks>
         <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 

--- a/src/IKVM.NET.Sdk.Tests/IKVM.NET.Sdk.Tests.csproj
+++ b/src/IKVM.NET.Sdk.Tests/IKVM.NET.Sdk.Tests.csproj
@@ -2,7 +2,7 @@
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/IKVM.Tests/IKVM.Tests.csproj
+++ b/src/IKVM.Tests/IKVM.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PreserveCompilationContext>true</PreserveCompilationContext>
         <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>

--- a/src/IKVM.Tools.Tests/IKVM.Tools.Tests.csproj
+++ b/src/IKVM.Tools.Tests/IKVM.Tools.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/dist-tests/dist-tests.csproj
+++ b/src/dist-tests/dist-tests.csproj
@@ -10,6 +10,7 @@
         <TestTarget Include="IKVM.ByteCode.Tests|net461" ProjectName="IKVM.ByteCode.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.ByteCode.Tests|netcoreapp3.1" ProjectName="IKVM.ByteCode.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.ByteCode.Tests|net6.0" ProjectName="IKVM.ByteCode.Tests" TargetFramework="net6.0" />
+        <TestTarget Include="IKVM.ByteCode.Tests|net7.0" ProjectName="IKVM.ByteCode.Tests" TargetFramework="net7.0" />
         <TestTarget Include="IKVM.Tests|net461" ProjectName="IKVM.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.Tests|netcoreapp3.1" ProjectName="IKVM.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.Tests|net6.0" ProjectName="IKVM.Tests" TargetFramework="net6.0" />

--- a/src/dist-tests/dist-tests.csproj
+++ b/src/dist-tests/dist-tests.csproj
@@ -13,11 +13,13 @@
         <TestTarget Include="IKVM.Tests|net461" ProjectName="IKVM.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.Tests|netcoreapp3.1" ProjectName="IKVM.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.Tests|net6.0" ProjectName="IKVM.Tests" TargetFramework="net6.0" />
+        <TestTarget Include="IKVM.Tests|net7.0" ProjectName="IKVM.Tests" TargetFramework="net7.0" />
         <TestTarget Include="IKVM.Java.Tests|net461" ProjectName="IKVM.Java.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.Java.Tests|netcoreapp3.1" ProjectName="IKVM.Java.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.Tools.Tests|net461" ProjectName="IKVM.Tools.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.Tools.Tests|netcoreapp3.1" ProjectName="IKVM.Tools.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.Tools.Tests|net6.0" ProjectName="IKVM.Tools.Tests" TargetFramework="net6.0" />
+        <TestTarget Include="IKVM.Tools.Tests|net7.0" ProjectName="IKVM.Tools.Tests" TargetFramework="net7.0" />
         <TestTarget Include="IKVM.Tools.Exporter.Tests|net461" ProjectName="IKVM.Tools.Exporter.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.Tools.Exporter.Tests|netcoreapp3.1" ProjectName="IKVM.Tools.Exporter.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.Tools.Importer.Tests|net461" ProjectName="IKVM.Tools.Importer.Tests" TargetFramework="net461" />
@@ -25,11 +27,13 @@
         <TestTarget Include="IKVM.MSBuild.Tasks.Tests|net472" ProjectName="IKVM.MSBuild.Tasks.Tests" TargetFramework="net472" />
         <TestTarget Include="IKVM.MSBuild.Tasks.Tests|netcoreapp3.1" ProjectName="IKVM.MSBuild.Tasks.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.MSBuild.Tasks.Tests|net6.0" ProjectName="IKVM.MSBuild.Tasks.Tests" TargetFramework="net6.0" />
-        <TestTarget Include="IKVM.MSBuild.Tests|net6.0" ProjectName="IKVM.MSBuild.Tests" TargetFramework="net6.0" />
-        <TestTarget Include="IKVM.NET.Sdk.Tests|net6.0" ProjectName="IKVM.NET.Sdk.Tests" TargetFramework="net6.0" />
+        <TestTarget Include="IKVM.MSBuild.Tasks.Tests|net7.0" ProjectName="IKVM.MSBuild.Tasks.Tests" TargetFramework="net7.0" />
+        <TestTarget Include="IKVM.MSBuild.Tests|net7.0" ProjectName="IKVM.MSBuild.Tests" TargetFramework="net7.0" />
+        <TestTarget Include="IKVM.NET.Sdk.Tests|net7.0" ProjectName="IKVM.NET.Sdk.Tests" TargetFramework="net7.0" />
         <TestTarget Include="IKVM.JTReg.TestAdapter.Tests|net461" ProjectName="IKVM.JTReg.TestAdapter.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.JTReg.TestAdapter.Tests|netcoreapp3.1" ProjectName="IKVM.JTReg.TestAdapter.Tests" TargetFramework="netcoreapp3.1" />
         <TestTarget Include="IKVM.JTReg.TestAdapter.Tests|net6.0" ProjectName="IKVM.JTReg.TestAdapter.Tests" TargetFramework="net6.0" />
+        <TestTarget Include="IKVM.JTReg.TestAdapter.Tests|net7.0" ProjectName="IKVM.JTReg.TestAdapter.Tests" TargetFramework="net7.0" />
         <TestTarget Include="IKVM.OpenJDK.Tests|net461" ProjectName="IKVM.OpenJDK.Tests" TargetFramework="net461" />
         <TestTarget Include="IKVM.OpenJDK.Tests|netcoreapp3.1" ProjectName="IKVM.OpenJDK.Tests" TargetFramework="netcoreapp3.1" />
     </ItemGroup>


### PR DESCRIPTION
Few projects where .NET 6 builds are enabled, add a .NET 7 build; and a .NET 7 test run. Move SDK/MSBuild test runner to .NET 7.