### PR TITLE
include ikvm.runtime dir in boot lib path

### DIFF
--- a/src/IKVM.Runtime/JVM.Properties.cs
+++ b/src/IKVM.Runtime/JVM.Properties.cs
@@ -649,6 +649,9 @@ namespace IKVM.Runtime
                 if (self == null)
                     yield break;
 
+                // implicitly include native libraries along side application (publish)
+                yield return self;
+
                 // search in runtime specific directories
                 foreach (var rid in RuntimeUtil.SupportedRuntimeIdentifiers)
                     yield return Path.Combine(self, "runtimes", rid, "native");


### PR DESCRIPTION
dotnet publish with RID throws all the native libraries into the single output dir. Theres no good reason for them to do this, but there ya go. Does it for Core too. It really shouldn't. It also doesn't fix paths in deps.json, so I have no idea how this is supposed to work!