### PR TITLE
Use JNICALL for exported functions.

### DIFF
--- a/src/IKVM.Runtime/JNI/JNIVM.cs
+++ b/src/IKVM.Runtime/JNI/JNIVM.cs
@@ -42,13 +42,19 @@ namespace IKVM.Runtime.JNI
         static class LibJvm
         {
 
-            public delegate int JNI_GetDefaultJavaVMInitArgsDelegate(void* vm_args);
-            public delegate int JNI_GetCreatedJavaVMs(JavaVM** vmBuf, jsize bufLen, jsize* nVMs);
-            public delegate int JNI_CreateJavaVM(JavaVM** p_vm, void** p_env, void* vm_args);
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate int JNI_GetDefaultJavaVMInitArgsFunc(void* vm_args);
 
-            delegate void Set_JNI_GetDefaultJavaVMInitArgsDelegate(JNI_GetDefaultJavaVMInitArgsDelegate func);
-            delegate void Set_JNI_GetCreatedJavaVMsDelegate(JNI_GetCreatedJavaVMs func);
-            delegate void Set_JNI_CreateJavaVMDelegate(JNI_CreateJavaVM func);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate int JNI_GetCreatedJavaVMsFunc(JavaVM** vmBuf, jsize bufLen, jsize* nVMs);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate int JNI_CreateJavaVMFunc(JavaVM** p_vm, void** p_env, void* vm_args);
+
+            delegate void Set_JNI_GetDefaultJavaVMInitArgsDelegate(JNI_GetDefaultJavaVMInitArgsFunc func);
+            delegate void Set_JNI_GetCreatedJavaVMsDelegate(JNI_GetCreatedJavaVMsFunc func);
+            delegate void Set_JNI_CreateJavaVMDelegate(JNI_CreateJavaVMFunc func);
 
             readonly static Set_JNI_GetDefaultJavaVMInitArgsDelegate set_JNI_GetDefaultJavaVMInitArgs;
             readonly static Set_JNI_GetCreatedJavaVMsDelegate set_JNI_GetCreatedJavaVMs;
@@ -65,11 +71,11 @@ namespace IKVM.Runtime.JNI
                 set_JNI_CreateJavaVM = Marshal.GetDelegateForFunctionPointer<Set_JNI_CreateJavaVMDelegate>(NativeLibrary.GetExport(p, "Set_JNI_CreateJavaVM", 1));
             }
 
-            public static void Set_JNI_GetDefaultJavaVMInitArgs(JNI_GetDefaultJavaVMInitArgsDelegate func) => set_JNI_GetDefaultJavaVMInitArgs(func);
+            public static void Set_JNI_GetDefaultJavaVMInitArgs(JNI_GetDefaultJavaVMInitArgsFunc func) => set_JNI_GetDefaultJavaVMInitArgs(func);
 
-            public static void Set_JNI_GetCreatedJavaVMs(JNI_GetCreatedJavaVMs func) => set_JNI_GetCreatedJavaVMs(func);
+            public static void Set_JNI_GetCreatedJavaVMs(JNI_GetCreatedJavaVMsFunc func) => set_JNI_GetCreatedJavaVMs(func);
 
-            public static void Set_JNI_CreateJavaVM(JNI_CreateJavaVM func) => set_JNI_CreateJavaVM(func);
+            public static void Set_JNI_CreateJavaVM(JNI_CreateJavaVMFunc func) => set_JNI_CreateJavaVM(func);
 
         }
 
@@ -86,9 +92,9 @@ namespace IKVM.Runtime.JNI
 
 #if FIRST_PASS == false
 
-        static readonly LibJvm.JNI_GetDefaultJavaVMInitArgsDelegate jni_GetDefaultJavaVMInitArgsDelegate = GetDefaultJavaVMInitArgs;
-        static readonly LibJvm.JNI_GetCreatedJavaVMs jni_GetCreatedJavaVMs = GetCreatedJavaVMs;
-        static readonly LibJvm.JNI_CreateJavaVM jni_CreateJavaVM = CreateJavaVM;
+        static readonly LibJvm.JNI_GetDefaultJavaVMInitArgsFunc jni_GetDefaultJavaVMInitArgsDelegate = GetDefaultJavaVMInitArgs;
+        static readonly LibJvm.JNI_GetCreatedJavaVMsFunc jni_GetCreatedJavaVMs = GetCreatedJavaVMs;
+        static readonly LibJvm.JNI_CreateJavaVMFunc jni_CreateJavaVM = CreateJavaVM;
 
         /// <summary>
         /// Initializes the static instance.

--- a/src/libjvm/jni.c
+++ b/src/libjvm/jni.c
@@ -8,17 +8,17 @@ static JNI_GetDefaultJavaVMInitArgs_Func *JNI_GetDefaultJavaVMInitArgs_Ptr;
 static JNI_GetCreatedJavaVMs_Func *JNI_GetCreatedJavaVMs_Ptr;
 static JNI_CreateJavaVM_Func *JNI_CreateJavaVM_Ptr;
 
-JNIEXPORT void Set_JNI_GetDefaultJavaVMInitArgs(JNI_GetDefaultJavaVMInitArgs_Func *func)
+JNIEXPORT void JNICALL Set_JNI_GetDefaultJavaVMInitArgs(JNI_GetDefaultJavaVMInitArgs_Func *func)
 {
     JNI_GetDefaultJavaVMInitArgs_Ptr = func;
 }
 
-JNIEXPORT void Set_JNI_GetCreatedJavaVMs(JNI_GetCreatedJavaVMs_Func *func)
+JNIEXPORT void JNICALL Set_JNI_GetCreatedJavaVMs(JNI_GetCreatedJavaVMs_Func *func)
 {
     JNI_GetCreatedJavaVMs_Ptr = func;
 }
 
-JNIEXPORT void Set_JNI_CreateJavaVM(JNI_CreateJavaVM_Func *func)
+JNIEXPORT void JNICALL Set_JNI_CreateJavaVM(JNI_CreateJavaVM_Func *func)
 {
     JNI_CreateJavaVM_Ptr = func;
 }


### PR DESCRIPTION
Exported Set_ functions should be JNICALL, since that takes care of Windows stdcall.
However, callbacks are not exported, and so should be cdecl.