### PR TITLE
Move Static Initializer out of Module Init path

### DIFF
--- a/src/IKVM.Runtime/Accessors/AccessorRef.cs
+++ b/src/IKVM.Runtime/Accessors/AccessorRef.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Gets the accessor value.
         /// </summary>
-        public T Value => JVM.BaseAccessors.Get(ref accessor);
+        public T Value => JVM.Internal.BaseAccessors.Get(ref accessor);
 
     }
 

--- a/src/IKVM.Runtime/ByteCodeHelper.cs
+++ b/src/IKVM.Runtime/ByteCodeHelper.cs
@@ -57,7 +57,7 @@ namespace IKVM.Runtime
 
         static ObjectAccessor objectAccessor;
 
-        static ObjectAccessor ObjectAccessor => JVM.BaseAccessors.Get(ref objectAccessor);
+        static ObjectAccessor ObjectAccessor => JVM.Internal.BaseAccessors.Get(ref objectAccessor);
 
 #endif
 
@@ -209,7 +209,7 @@ namespace IKVM.Runtime
                 if (loader != null)
                 {
                     ClassLoaderAccessor cla = null;
-                    JVM.BaseAccessors.Get(ref cla);
+                    JVM.Internal.BaseAccessors.Get(ref cla);
                     cla.InvokeCheckPackageAccess(loader, wrapper.ClassObject, callerId.getCallerClass().pd);
                 }
 

--- a/src/IKVM.Runtime/ClassLiteral.cs
+++ b/src/IKVM.Runtime/ClassLiteral.cs
@@ -17,7 +17,7 @@ namespace IKVM.Runtime
         static ClassAccessor classAccessor;
         static object value;
 
-        static ClassAccessor ClassAccessor => JVM.BaseAccessors.Get(ref classAccessor);
+        static ClassAccessor ClassAccessor => JVM.Internal.BaseAccessors.Get(ref classAccessor);
 
         /// <summary>
         /// Gets the class literal value, caching the result.

--- a/src/IKVM.Runtime/JVM.Internal.cs
+++ b/src/IKVM.Runtime/JVM.Internal.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Diagnostics;
+using System.Security;
+using System.Text;
+using System.Threading;
+
+using IKVM.Runtime.Accessors;
+using IKVM.Runtime.Accessors.Java.Lang;
+using IKVM.Runtime.Vfs;
+
+#if IMPORTER || EXPORTER
+using IKVM.Reflection;
+using Type = IKVM.Reflection.Type;
+#else
+#endif
+
+#if IMPORTER
+using IKVM.Tools.Importer;
+#endif
+
+namespace IKVM.Runtime
+{
+
+    static partial class JVM
+    {
+
+        /// <summary>
+        /// Internal services of the JVM.
+        /// </summary>
+        /// <remarks>
+        /// JVM.Internal exists so that static initialization of JVM does not cause initialization of internal state.
+        /// </remarks>
+        internal static class Internal
+        {
+
+            internal const string JarClassList = "--ikvm-classes--/";
+
+#if FIRST_PASS == false && IMPORTER == false && EXPORTER == false
+
+            internal static readonly RuntimeContext context = new RuntimeContext(new RuntimeContextOptions(), new Resolver(), false);
+            internal static readonly VfsTable vfs = VfsTable.BuildDefaultTable(new VfsRuntimeContext(context), Properties.HomePath);
+            internal static readonly Lazy<object> systemThreadGroup = new Lazy<object>(() => ThreadGroupAccessor.Init());
+            internal static readonly Lazy<object> mainThreadGroup = new Lazy<object>(() => ThreadGroupAccessor.Init(null, SystemThreadGroup, "main"));
+
+            static AccessorCache baseAccessors;
+            static ThreadGroupAccessor threadGroupAccessor;
+            static SystemAccessor systemAccessor;
+
+            internal static AccessorCache BaseAccessors => AccessorCache.Get(ref baseAccessors, context.Resolver.ResolveBaseAssembly());
+
+            internal static ThreadGroupAccessor ThreadGroupAccessor => BaseAccessors.Get(ref threadGroupAccessor);
+
+            internal static SystemAccessor SystemAccessor => BaseAccessors.Get(ref systemAccessor);
+
+#endif
+
+        }
+
+    }
+
+}

--- a/src/IKVM.Runtime/Java/Externs/ikvm/runtime/AssemblyClassLoader.cs
+++ b/src/IKVM.Runtime/Java/Externs/ikvm/runtime/AssemblyClassLoader.cs
@@ -37,7 +37,7 @@ namespace IKVM.Java.Externs.ikvm.runtime
 
         static ClassLoaderAccessor classLoaderAccessor;
 
-        static ClassLoaderAccessor ClassLoaderAccessor => JVM.BaseAccessors.Get(ref classLoaderAccessor);
+        static ClassLoaderAccessor ClassLoaderAccessor => JVM.Internal.BaseAccessors.Get(ref classLoaderAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/java/io/FileDescriptor.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/io/FileDescriptor.cs
@@ -18,7 +18,7 @@ namespace IKVM.Java.Externs.java.io
 
         static FileDescriptorAccessor fileDescriptorAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/java/io/FileInputStream.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/io/FileInputStream.cs
@@ -21,9 +21,9 @@ namespace IKVM.Java.Externs.java.io
         static FileDescriptorAccessor fileDescriptorAccessor;
         static FileInputStreamAccessor fileInputStreamAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static FileInputStreamAccessor FileInputStreamAccessor => JVM.BaseAccessors.Get(ref fileInputStreamAccessor);
+        static FileInputStreamAccessor FileInputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref fileInputStreamAccessor);
 
         static global::ikvm.@internal.CallerID __callerID;
         delegate void __jniDelegate__open0(IntPtr jniEnv, IntPtr self, IntPtr path);

--- a/src/IKVM.Runtime/Java/Externs/java/io/FileOutputStream.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/io/FileOutputStream.cs
@@ -19,9 +19,9 @@ namespace IKVM.Java.Externs.java.io
         static FileDescriptorAccessor fileDescriptorAccessor;
         static FileOutputStreamAccessor fileOutputStreamAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static FileOutputStreamAccessor FileOutputStreamAccessor => JVM.BaseAccessors.Get(ref fileOutputStreamAccessor);
+        static FileOutputStreamAccessor FileOutputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref fileOutputStreamAccessor);
 
         static global::ikvm.@internal.CallerID __callerID;
         delegate void __jniDelegate__open0(IntPtr jniEnv, IntPtr this_, IntPtr path, sbyte append);

--- a/src/IKVM.Runtime/Java/Externs/java/io/RandomAccessFile.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/io/RandomAccessFile.cs
@@ -23,11 +23,11 @@ namespace IKVM.Java.Externs.java.io
 #if FIRST_PASS == false
 
         static FileDescriptorAccessor fileDescriptorAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 
         static RandomAccessFileAccessor randomAccessFileAccessor;
-        static RandomAccessFileAccessor RandomAccessFileAccessor => JVM.BaseAccessors.Get(ref randomAccessFileAccessor);
+        static RandomAccessFileAccessor RandomAccessFileAccessor => JVM.Internal.BaseAccessors.Get(ref randomAccessFileAccessor);
 
         static global::ikvm.@internal.CallerID __callerID;
         delegate void __jniDelegate__open0(IntPtr jniEnv, IntPtr self, IntPtr name, int mode);

--- a/src/IKVM.Runtime/Java/Externs/java/lang/Class.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/lang/Class.cs
@@ -40,7 +40,7 @@ namespace IKVM.Java.Externs.java.lang
 
         static ClassLoaderAccessor classLoaderAccessor;
 
-        static ClassLoaderAccessor ClassLoaderAccessor => JVM.BaseAccessors.Get(ref classLoaderAccessor);
+        static ClassLoaderAccessor ClassLoaderAccessor => JVM.Internal.BaseAccessors.Get(ref classLoaderAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/java/lang/ProcessImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/lang/ProcessImpl.cs
@@ -47,47 +47,47 @@ namespace IKVM.Java.Externs.java.lang
         static IteratorAccessor iteratorAccessor;
         static ProcessImplAccessor processImplAccessor;
 
-        static CallerIDAccessor CallerIDAccessor => JVM.BaseAccessors.Get(ref callerIDAccessor);
+        static CallerIDAccessor CallerIDAccessor => JVM.Internal.BaseAccessors.Get(ref callerIDAccessor);
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static SecurityManagerAccessor SecurityManagerAccessor => JVM.BaseAccessors.Get(ref securityManagerAccessor);
+        static SecurityManagerAccessor SecurityManagerAccessor => JVM.Internal.BaseAccessors.Get(ref securityManagerAccessor);
 
-        static ThreadAccessor ThreadAccessor => JVM.BaseAccessors.Get(ref threadAccessor);
+        static ThreadAccessor ThreadAccessor => JVM.Internal.BaseAccessors.Get(ref threadAccessor);
 
-        static ProcessBuilderRedirectAccessor ProcessBuilderRedirectAccessor => JVM.BaseAccessors.Get(ref processBuilderRedirectAccessor);
+        static ProcessBuilderRedirectAccessor ProcessBuilderRedirectAccessor => JVM.Internal.BaseAccessors.Get(ref processBuilderRedirectAccessor);
 
-        static ProcessBuilderNullInputStreamAccessor ProcessBuilderNullInputStreamAccessor => JVM.BaseAccessors.Get(ref processBuilderNullInputStreamAccessor);
+        static ProcessBuilderNullInputStreamAccessor ProcessBuilderNullInputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref processBuilderNullInputStreamAccessor);
 
-        static ProcessBuilderNullOutputStreamAccessor ProcessBuilderNullOutputStreamAccessor => JVM.BaseAccessors.Get(ref processBuilderNullOutputStreamAccessor);
+        static ProcessBuilderNullOutputStreamAccessor ProcessBuilderNullOutputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref processBuilderNullOutputStreamAccessor);
 
-        static FileAccessor FileAccessor => JVM.BaseAccessors.Get(ref fileAccessor);
+        static FileAccessor FileAccessor => JVM.Internal.BaseAccessors.Get(ref fileAccessor);
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static InputStreamAccessor InputStreamAccessor => JVM.BaseAccessors.Get(ref inputStreamAccessor);
+        static InputStreamAccessor InputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref inputStreamAccessor);
 
-        static OutputStreamAccessor OutputStreamAccessor => JVM.BaseAccessors.Get(ref outputStreamAccessor);
+        static OutputStreamAccessor OutputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref outputStreamAccessor);
 
-        static FileInputStreamAccessor FileInputStreamAccessor => JVM.BaseAccessors.Get(ref fileInputStreamAccessor);
+        static FileInputStreamAccessor FileInputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref fileInputStreamAccessor);
 
-        static FileOutputStreamAccessor FileOutputStreamAccessor => JVM.BaseAccessors.Get(ref fileOutputStreamAccessor);
+        static FileOutputStreamAccessor FileOutputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref fileOutputStreamAccessor);
 
-        static BufferedInputStreamAccessor BufferedInputStreamAccessor => JVM.BaseAccessors.Get(ref bufferedInputStreamAccessor);
+        static BufferedInputStreamAccessor BufferedInputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref bufferedInputStreamAccessor);
 
-        static BufferedOutputStreamAccessor BufferedOutputStreamAccessor => JVM.BaseAccessors.Get(ref bufferedOutputStreamAccessor);
+        static BufferedOutputStreamAccessor BufferedOutputStreamAccessor => JVM.Internal.BaseAccessors.Get(ref bufferedOutputStreamAccessor);
 
-        static AccessControllerAccessor AccessControllerAccessor => JVM.BaseAccessors.Get(ref accessControllerAccessor);
+        static AccessControllerAccessor AccessControllerAccessor => JVM.Internal.BaseAccessors.Get(ref accessControllerAccessor);
 
-        static MapAccessor MapAccessor => JVM.BaseAccessors.Get(ref mapAccessor);
+        static MapAccessor MapAccessor => JVM.Internal.BaseAccessors.Get(ref mapAccessor);
 
-        static MapEntryAccessor MapEntryAccessor => JVM.BaseAccessors.Get(ref mapEntryAccessor);
+        static MapEntryAccessor MapEntryAccessor => JVM.Internal.BaseAccessors.Get(ref mapEntryAccessor);
 
-        static SetAccessor SetAccessor => JVM.BaseAccessors.Get(ref setAccessor);
+        static SetAccessor SetAccessor => JVM.Internal.BaseAccessors.Get(ref setAccessor);
 
-        static IteratorAccessor IteratorAccessor => JVM.BaseAccessors.Get(ref iteratorAccessor);
+        static IteratorAccessor IteratorAccessor => JVM.Internal.BaseAccessors.Get(ref iteratorAccessor);
 
-        static ProcessImplAccessor ProcessImplAccessor => JVM.BaseAccessors.Get(ref processImplAccessor);
+        static ProcessImplAccessor ProcessImplAccessor => JVM.Internal.BaseAccessors.Get(ref processImplAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/java/lang/System.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/lang/System.cs
@@ -20,9 +20,9 @@ namespace IKVM.Java.Externs.java.lang
         static SystemAccessor systemAccessor;
         static PropertiesAccessor propertiesAccessor;
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static PropertiesAccessor PropertiesAccessor => JVM.BaseAccessors.Get(ref propertiesAccessor);
+        static PropertiesAccessor PropertiesAccessor => JVM.Internal.BaseAccessors.Get(ref propertiesAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/java/lang/Thread.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/lang/Thread.cs
@@ -45,9 +45,9 @@ namespace IKVM.Java.Externs.java.lang
         static AccessControllerAccessor accessControllerAccessor;
         static ThreadAccessor threadAccessor;
 
-        static AccessControllerAccessor AccessControllerAccessor => JVM.BaseAccessors.Get(ref accessControllerAccessor);
+        static AccessControllerAccessor AccessControllerAccessor => JVM.Internal.BaseAccessors.Get(ref accessControllerAccessor);
 
-        static ThreadAccessor ThreadAccessor => JVM.BaseAccessors.Get(ref threadAccessor);
+        static ThreadAccessor ThreadAccessor => JVM.Internal.BaseAccessors.Get(ref threadAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/java/net/PlainDatagramSocketImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/net/PlainDatagramSocketImpl.cs
@@ -27,7 +27,7 @@ namespace IKVM.Java.Externs.java.net
 #if FIRST_PASS == false
 
         static FileDescriptorAccessor fileDescriptorAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
         /// <summary>
         /// Compiles a fast getter for a <see cref="FieldInfo"/>.

--- a/src/IKVM.Runtime/Java/Externs/java/net/PlainSocketImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/net/PlainSocketImpl.cs
@@ -28,9 +28,9 @@ namespace IKVM.Java.Externs.java.net
         static FileDescriptorAccessor fileDescriptorAccessor;
         static PlainSocketImplAccessor plainSocketImplAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static PlainSocketImplAccessor PlainSocketImplAccessor => JVM.BaseAccessors.Get(ref plainSocketImplAccessor);
+        static PlainSocketImplAccessor PlainSocketImplAccessor => JVM.Internal.BaseAccessors.Get(ref plainSocketImplAccessor);
 
         [Flags]
         enum HANDLE_FLAGS

--- a/src/IKVM.Runtime/Java/Externs/java/net/SocketInputStream.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/net/SocketInputStream.cs
@@ -18,7 +18,7 @@ namespace IKVM.Java.Externs.java.net
 
         static FileDescriptorAccessor fileDescriptorAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
         static global::ikvm.@internal.CallerID __callerID;
         delegate int __jniDelegate__socketRead0(IntPtr jniEnv, IntPtr self, IntPtr fdObj, IntPtr data, int off, int len, int timeout);

--- a/src/IKVM.Runtime/Java/Externs/java/net/SocketOutputStream.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/net/SocketOutputStream.cs
@@ -18,7 +18,7 @@ namespace IKVM.Java.Externs.java.net
 
         static FileDescriptorAccessor fileDescriptorAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
         static global::ikvm.@internal.CallerID __callerID;
         delegate void __jniDelegate__socketWrite0(IntPtr jniEnv, IntPtr self, IntPtr fdObj, IntPtr data, int off, int len);

--- a/src/IKVM.Runtime/Java/Externs/java/util/zip/ClassStubZipEntry.cs
+++ b/src/IKVM.Runtime/Java/Externs/java/util/zip/ClassStubZipEntry.cs
@@ -197,7 +197,7 @@ namespace IKVM.Java.Externs.java.util.zip
                 var path = zipFile.getName();
                 if (JVM.Vfs.IsPath(path))
                 {
-                    var entry = (global::java.util.zip.ZipEntry)entries.get(JVM.JarClassList);
+                    var entry = (global::java.util.zip.ZipEntry)entries.get(JVM.Internal.JarClassList);
                     if (entry != null)
                     {
                         using var stream = new ZipEntryStream(zipFile, entry);

--- a/src/IKVM.Runtime/Java/Externs/sun/misc/VM.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/misc/VM.cs
@@ -38,7 +38,7 @@ namespace IKVM.Java.Externs.sun.misc
 #if FIRST_PASS
             throw new NotImplementedException();
 #else
-            JVM.EnsureInitialized();
+            JVM.Init();
 #endif
         }
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DatagramChannelImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DatagramChannelImpl.cs
@@ -25,9 +25,9 @@ namespace IKVM.Java.Externs.sun.nio.ch
         static FileDescriptorAccessor fileDescriptorAccessor;
         static DatagramChannelImplAccessor datagramChannelImplAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static DatagramChannelImplAccessor DatagramChannelImplAccessor => JVM.BaseAccessors.Get(ref datagramChannelImplAccessor);
+        static DatagramChannelImplAccessor DatagramChannelImplAccessor => JVM.Internal.BaseAccessors.Get(ref datagramChannelImplAccessor);
 
         /// <summary>
         /// Compiles a fast setter for a <see cref="FieldInfo"/>.

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DatagramDispatcher.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DatagramDispatcher.cs
@@ -20,7 +20,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 #if FIRST_PASS == false
 
         static FileDescriptorAccessor fileDescriptorAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DotNetAsynchronousFileChannelImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DotNetAsynchronousFileChannelImpl.cs
@@ -40,7 +40,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 
         static FileDescriptorAccessor fileDescriptorAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DotNetAsynchronousServerSocketChannelImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DotNetAsynchronousServerSocketChannelImpl.cs
@@ -40,17 +40,17 @@ namespace IKVM.Java.Externs.sun.nio.ch
         static DotNetAsynchronousServerSocketChannelImplAccessor dotNetAsynchronousServerSocketChannelImplAccessor;
         static DotNetAsynchronousSocketChannelImplAccessor dotNetAsynchronousSocketChannelImplAccessor;
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static SecurityManagerAccessor SecurityManagerAccessor => JVM.BaseAccessors.Get(ref securityManagerAccessor);
+        static SecurityManagerAccessor SecurityManagerAccessor => JVM.Internal.BaseAccessors.Get(ref securityManagerAccessor);
 
-        static AccessControllerAccessor AccessControllerAccessor => JVM.BaseAccessors.Get(ref accessControllerAccessor);
+        static AccessControllerAccessor AccessControllerAccessor => JVM.Internal.BaseAccessors.Get(ref accessControllerAccessor);
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static DotNetAsynchronousServerSocketChannelImplAccessor DotNetAsynchronousServerSocketChannelImplAccessor => JVM.BaseAccessors.Get(ref dotNetAsynchronousServerSocketChannelImplAccessor);
+        static DotNetAsynchronousServerSocketChannelImplAccessor DotNetAsynchronousServerSocketChannelImplAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetAsynchronousServerSocketChannelImplAccessor);
 
-        static DotNetAsynchronousSocketChannelImplAccessor DotNetAsynchronousSocketChannelImplAccessor => JVM.BaseAccessors.Get(ref dotNetAsynchronousSocketChannelImplAccessor);
+        static DotNetAsynchronousSocketChannelImplAccessor DotNetAsynchronousSocketChannelImplAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetAsynchronousSocketChannelImplAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DotNetAsynchronousSocketChannelImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/DotNetAsynchronousSocketChannelImpl.cs
@@ -40,9 +40,9 @@ namespace IKVM.Java.Externs.sun.nio.ch
 
         static FileDescriptorAccessor fileDescriptorAccessor;
         static DotNetAsynchronousSocketChannelImplAccessor dotNetAsynchronousSocketChannelImplAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static DotNetAsynchronousSocketChannelImplAccessor DotNetAsynchronousSocketChannelImplAccessor => JVM.BaseAccessors.Get(ref dotNetAsynchronousSocketChannelImplAccessor);
+        static DotNetAsynchronousSocketChannelImplAccessor DotNetAsynchronousSocketChannelImplAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetAsynchronousSocketChannelImplAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/FileDispatcherImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/FileDispatcherImpl.cs
@@ -20,7 +20,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 
         static FileDescriptorAccessor fileDescriptorAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
         static global::ikvm.@internal.CallerID __callerID;
         delegate int __jniDelegate__read0(IntPtr jniEnv, IntPtr clazz, IntPtr fdo, long address, int len);

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/IOUtil.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/IOUtil.cs
@@ -18,7 +18,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 
         static FileDescriptorAccessor fileDescriptorAccessor;
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/Net.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/Net.cs
@@ -22,7 +22,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 #if FIRST_PASS == false
 
         static FileDescriptorAccessor fileDescriptorAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
         [StructLayout(LayoutKind.Explicit)]
         unsafe struct sockaddr_storage

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/ServerSocketChannelImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/ServerSocketChannelImpl.cs
@@ -18,7 +18,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 #if FIRST_PASS == false
 
         static FileDescriptorAccessor fileDescriptorAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/SocketChannelImpl.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/SocketChannelImpl.cs
@@ -18,7 +18,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 #if FIRST_PASS == false
 
         static FileDescriptorAccessor fileDescriptorAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/ch/SocketDispatcher.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/ch/SocketDispatcher.cs
@@ -19,7 +19,7 @@ namespace IKVM.Java.Externs.sun.nio.ch
 #if FIRST_PASS == false
 
         static FileDescriptorAccessor fileDescriptorAccessor;
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetBasicFileAttributeView.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetBasicFileAttributeView.cs
@@ -23,13 +23,13 @@ namespace IKVM.Java.Externs.sun.nio.fs
         static FileTimeAccessor fileTimeAccessor;
         static DotNetBasicFileAttributeViewAccessor dotNetBasicFileAttributeViewAccessor;
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static SecurityManagerAccessor SecurityManagerAccessor => JVM.BaseAccessors.Get(ref securityManagerAccessor);
+        static SecurityManagerAccessor SecurityManagerAccessor => JVM.Internal.BaseAccessors.Get(ref securityManagerAccessor);
 
-        static FileTimeAccessor FileTimeAccessor => JVM.BaseAccessors.Get(ref fileTimeAccessor);
+        static FileTimeAccessor FileTimeAccessor => JVM.Internal.BaseAccessors.Get(ref fileTimeAccessor);
 
-        static DotNetBasicFileAttributeViewAccessor DotNetBasicFileAttributeViewAccessor => JVM.BaseAccessors.Get(ref dotNetBasicFileAttributeViewAccessor);
+        static DotNetBasicFileAttributeViewAccessor DotNetBasicFileAttributeViewAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetBasicFileAttributeViewAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetDirectoryStream.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetDirectoryStream.cs
@@ -23,13 +23,13 @@ namespace IKVM.Java.Externs.sun.nio.fs
         static DotNetPathAccessor dotNetPathAccessor;
         static DotNetDirectoryStreamAccessor dotNetDirectoryStreamAccessor;
 
-        static EnumeratorIteratorAccessor EnumeratorIteratorAccessor => JVM.BaseAccessors.Get(ref enumeratorIteratorAccessor);
+        static EnumeratorIteratorAccessor EnumeratorIteratorAccessor => JVM.Internal.BaseAccessors.Get(ref enumeratorIteratorAccessor);
 
-        static DirectoryStreamFilterAccessor DirectoryStreamFilterAccessor => JVM.BaseAccessors.Get(ref directoryStreamFilterAccessor);
+        static DirectoryStreamFilterAccessor DirectoryStreamFilterAccessor => JVM.Internal.BaseAccessors.Get(ref directoryStreamFilterAccessor);
 
-        static DotNetPathAccessor DotNetPathAccessor => JVM.BaseAccessors.Get(ref dotNetPathAccessor);
+        static DotNetPathAccessor DotNetPathAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetPathAccessor);
 
-        static DotNetDirectoryStreamAccessor DotNetDirectoryStreamAccessor => JVM.BaseAccessors.Get(ref dotNetDirectoryStreamAccessor);
+        static DotNetDirectoryStreamAccessor DotNetDirectoryStreamAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetDirectoryStreamAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetDosFileAttributeView.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetDosFileAttributeView.cs
@@ -19,9 +19,9 @@ namespace IKVM.Java.Externs.sun.nio.fs
         static SystemAccessor systemAccessor;
         static SecurityManagerAccessor securityManagerAccessor;
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static SecurityManagerAccessor SecurityManagerAccessor => JVM.BaseAccessors.Get(ref securityManagerAccessor);
+        static SecurityManagerAccessor SecurityManagerAccessor => JVM.Internal.BaseAccessors.Get(ref securityManagerAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetDosFileAttributes.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetDosFileAttributes.cs
@@ -23,13 +23,13 @@ namespace IKVM.Java.Externs.sun.nio.fs
         static FileTimeAccessor fileTimeAccessor;
         static DotNetDosFileAttributesAccessor dotNetDosFileAttributesAccessor;
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static FileTimeAccessor FileTimeAccessor => JVM.BaseAccessors.Get(ref fileTimeAccessor);
+        static FileTimeAccessor FileTimeAccessor => JVM.Internal.BaseAccessors.Get(ref fileTimeAccessor);
 
-        static SecurityManagerAccessor SecurityManagerAccessor => JVM.BaseAccessors.Get(ref securityManagerAccessor);
+        static SecurityManagerAccessor SecurityManagerAccessor => JVM.Internal.BaseAccessors.Get(ref securityManagerAccessor);
 
-        static DotNetDosFileAttributesAccessor DotNetDosFileAttributesAccessor => JVM.BaseAccessors.Get(ref dotNetDosFileAttributesAccessor);
+        static DotNetDosFileAttributesAccessor DotNetDosFileAttributesAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetDosFileAttributesAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetFileSystemProvider.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/nio/fs/DotNetFileSystemProvider.cs
@@ -33,15 +33,15 @@ namespace IKVM.Java.Externs.sun.nio.fs
         static DotNetPathAccessor dotNetPathAccessor;
         static DotNetDirectoryStreamAccessor dotNetDirectoryStreamAccessor;
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static SecurityManagerAccessor SecurityManagerAccessor => JVM.BaseAccessors.Get(ref securityManagerAccessor);
+        static SecurityManagerAccessor SecurityManagerAccessor => JVM.Internal.BaseAccessors.Get(ref securityManagerAccessor);
 
-        static FileDescriptorAccessor FileDescriptorAccessor => JVM.BaseAccessors.Get(ref fileDescriptorAccessor);
+        static FileDescriptorAccessor FileDescriptorAccessor => JVM.Internal.BaseAccessors.Get(ref fileDescriptorAccessor);
 
-        static DotNetPathAccessor DotNetPathAccessor => JVM.BaseAccessors.Get(ref dotNetPathAccessor);
+        static DotNetPathAccessor DotNetPathAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetPathAccessor);
 
-        static DotNetDirectoryStreamAccessor DotNetDirectoryStreamAccessor => JVM.BaseAccessors.Get(ref dotNetDirectoryStreamAccessor);
+        static DotNetDirectoryStreamAccessor DotNetDirectoryStreamAccessor => JVM.Internal.BaseAccessors.Get(ref dotNetDirectoryStreamAccessor);
 
 #if NETCOREAPP
 

--- a/src/IKVM.Runtime/Java/Externs/sun/reflect/ReflectionFactory.cs
+++ b/src/IKVM.Runtime/Java/Externs/sun/reflect/ReflectionFactory.cs
@@ -43,7 +43,7 @@ namespace IKVM.Java.Externs.sun.reflect
 
         static SystemAccessor systemAccessor;
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
 #endif
 

--- a/src/IKVM.Runtime/Launcher.cs
+++ b/src/IKVM.Runtime/Launcher.cs
@@ -39,19 +39,19 @@ namespace IKVM.Runtime
         static ThreadGroupAccessor threadGroupAccessor;
         static LauncherHelperAccessor launcherHelperAccessor;
 
-        static CallerIDAccessor CallerIDAccessor => JVM.BaseAccessors.Get(ref callerIDAccessor);
+        static CallerIDAccessor CallerIDAccessor => JVM.Internal.BaseAccessors.Get(ref callerIDAccessor);
 
-        static ClassAccessor ClassAccessor => JVM.BaseAccessors.Get(ref classAccessor);
+        static ClassAccessor ClassAccessor => JVM.Internal.BaseAccessors.Get(ref classAccessor);
 
-        static MethodAccessor MethodAccessor => JVM.BaseAccessors.Get(ref methodAccessor);
+        static MethodAccessor MethodAccessor => JVM.Internal.BaseAccessors.Get(ref methodAccessor);
 
-        static SystemAccessor SystemAccessor => JVM.BaseAccessors.Get(ref systemAccessor);
+        static SystemAccessor SystemAccessor => JVM.Internal.BaseAccessors.Get(ref systemAccessor);
 
-        static ThreadAccessor ThreadAccessor => JVM.BaseAccessors.Get(ref threadAccessor);
+        static ThreadAccessor ThreadAccessor => JVM.Internal.BaseAccessors.Get(ref threadAccessor);
 
-        static ThreadGroupAccessor ThreadGroupAccessor => JVM.BaseAccessors.Get(ref threadGroupAccessor);
+        static ThreadGroupAccessor ThreadGroupAccessor => JVM.Internal.BaseAccessors.Get(ref threadGroupAccessor);
 
-        static LauncherHelperAccessor LauncherHelperAccessor => JVM.BaseAccessors.Get(ref launcherHelperAccessor);
+        static LauncherHelperAccessor LauncherHelperAccessor => JVM.Internal.BaseAccessors.Get(ref launcherHelperAccessor);
 
 #endif
 
@@ -405,7 +405,7 @@ namespace IKVM.Runtime
 
                     if (ArgEquals(arg, "-Xverify"))
                     {
-                        JVM.relaxedVerification = false;
+                        JVM.RelaxedVerification = false;
                         continue;
                     }
 
@@ -497,7 +497,7 @@ namespace IKVM.Runtime
                 SetUserProperties(initialize);
 
                 // VM initialization, configures system properties, done before any static initializers
-                JVM.EnsureInitialized();
+                JVM.Init();
 
                 // first entry into base assembly
                 EnterMainThread();

--- a/src/IKVM.Runtime/RuntimeClassLoader.cs
+++ b/src/IKVM.Runtime/RuntimeClassLoader.cs
@@ -64,7 +64,7 @@ namespace IKVM.Runtime
 #if !IMPORTER && !FIRST_PASS && !EXPORTER
 
         ClassLoaderAccessor classLoaderAccessor;
-        ClassLoaderAccessor ClassLoaderAccessor => JVM.BaseAccessors.Get(ref classLoaderAccessor);
+        ClassLoaderAccessor ClassLoaderAccessor => JVM.Internal.BaseAccessors.Get(ref classLoaderAccessor);
 
         protected java.lang.ClassLoader javaClassLoader;
 
@@ -275,7 +275,7 @@ namespace IKVM.Runtime
 #if FIRST_PASS
                 return true;
 #else
-                return JVM.relaxedVerification && (javaClassLoader == null || IsTrusted);
+                return JVM.RelaxedVerification && (javaClassLoader == null || IsTrusted);
 #endif
             }
         }

--- a/src/IKVM.Runtime/RuntimeInit.cs
+++ b/src/IKVM.Runtime/RuntimeInit.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using IKVM.Attributes;
+
+namespace IKVM.Runtime
+{
+
+    /// <summary>
+    /// Initializes the JVM at module load.
+    /// </summary>
+    static class RuntimeInit
+    {
+
+#if FIRST_PASS == false && IMPORTER == false && EXPORTER == false
+
+        /// <summary>
+        /// Invoked on module initialize to load the JVM.
+        /// </summary>
+#pragma warning disable CA2255
+        [ModuleInitializer]
+#pragma warning restore CA2255
+        internal static void Init()
+        {
+            // if our entry point is a Java application it will initialize the JVM as part of the launcher
+            var isJavaApp = Assembly.GetEntryAssembly()?.ManifestModule?.GetCustomAttributes<JavaModuleAttribute>().Any() ?? false;
+            if (isJavaApp == false)
+                JVM.EnsureInitialized();
+        }
+
+#endif
+
+    }
+
+}

--- a/src/IKVM.Runtime/RuntimeInit.cs
+++ b/src/IKVM.Runtime/RuntimeInit.cs
@@ -26,7 +26,7 @@ namespace IKVM.Runtime
             // if our entry point is a Java application it will initialize the JVM as part of the launcher
             var isJavaApp = Assembly.GetEntryAssembly()?.ManifestModule?.GetCustomAttributes<JavaModuleAttribute>().Any() ?? false;
             if (isJavaApp == false)
-                JVM.EnsureInitialized();
+                JVM.Init();
         }
 
 #endif

--- a/src/IKVM.Runtime/Util/Java/Nio/DirectBufferMemoryManager.cs
+++ b/src/IKVM.Runtime/Util/Java/Nio/DirectBufferMemoryManager.cs
@@ -18,7 +18,7 @@ namespace IKVM.Runtime.Util.Java.Nio
     {
 
         static BufferAccessor bufferAccessor;
-        static BufferAccessor BufferAccessor => JVM.BaseAccessors.Get(ref bufferAccessor);
+        static BufferAccessor BufferAccessor => JVM.Internal.BaseAccessors.Get(ref bufferAccessor);
 
         readonly object buffer;
 

--- a/src/IKVM.Tools.Importer/CompilerClassLoader.cs
+++ b/src/IKVM.Tools.Importer/CompilerClassLoader.cs
@@ -779,7 +779,7 @@ namespace IKVM.Tools.Importer
                     if (stubs.Count != 0)
                     {
                         // generate the --ikvm-classes-- file in the jar
-                        ZipArchiveEntry zipEntry = zip.CreateEntry(JVM.JarClassList);
+                        ZipArchiveEntry zipEntry = zip.CreateEntry(JVM.Internal.JarClassList);
 
                         using Stream stream = zipEntry.Open();
                         using BinaryWriter bw = new BinaryWriter(stream);


### PR DESCRIPTION
Circumstances where the ModuleInitializer in JVM could cause static initialization to proceed before module init has a chance to make a determination.