### PR TITLE
Add IgnoresAccessChecksToAttribute into generated assemblies

### DIFF
--- a/src/IKVM.MSBuild.Tasks/IkvmReferenceItemPrepare.cs
+++ b/src/IKVM.MSBuild.Tasks/IkvmReferenceItemPrepare.cs
@@ -196,7 +196,6 @@
         /// <summary>
         /// Attempts to load the state file.
         /// </summary>
-        /// <param name="cancellationToken"></param>
         internal void LoadState()
         {
             if (StateFile != null && File.Exists(StateFile))

--- a/src/IKVM.Runtime/AttributeHelper.cs
+++ b/src/IKVM.Runtime/AttributeHelper.cs
@@ -63,10 +63,10 @@ namespace IKVM.Runtime
 
 #if IMPORTER
 
-        CustomAttributeBuilder compilerGeneratedAttribute;
-        CustomAttributeBuilder ghostInterfaceAttribute;
-        CustomAttributeBuilder deprecatedAttribute;
-        CustomAttributeBuilder editorBrowsableNever;
+
+        Type typeofModifiers;
+        Type typeofSourceFileAttribute;
+        Type typeofLineNumberTableAttribute;
         ConstructorInfo implementsAttribute;
         ConstructorInfo throwsAttribute;
         ConstructorInfo sourceFileAttribute;
@@ -77,13 +77,12 @@ namespace IKVM.Runtime
         ConstructorInfo methodParametersAttribute;
         ConstructorInfo runtimeVisibleTypeAnnotationsAttribute;
         ConstructorInfo constantPoolAttribute;
-        CustomAttributeBuilder paramArrayAttribute;
         ConstructorInfo nonNestedInnerClassAttribute;
         ConstructorInfo nonNestedOuterClassAttribute;
-
-        Type typeofModifiers;
-        Type typeofSourceFileAttribute;
-        Type typeofLineNumberTableAttribute;
+        CustomAttributeBuilder paramArrayAttribute;
+        CustomAttributeBuilder ghostInterfaceAttribute;
+        CustomAttributeBuilder deprecatedAttribute;
+        CustomAttributeBuilder editorBrowsableNever;
 
 #endif
 
@@ -110,65 +109,70 @@ namespace IKVM.Runtime
         Type typeofRuntimeVisibleTypeAnnotationsAttribute;
         Type typeofConstantPoolAttribute;
         Type typeofDebuggableAttribute;
+        Type typeofAttributeUsageAttribute;
+        ConstructorInfo debuggableAttribute;
+        ConstructorInfo attributeUsageAttribute;
         CustomAttributeBuilder hideFromJavaAttribute;
         CustomAttributeBuilder hideFromReflection;
-        ConstructorInfo debuggableAttribute;
+        CustomAttributeBuilder compilerGeneratedAttribute;
 
 #if IMPORTER
 
-        Type TypeOfModifiers => typeofModifiers ??= LoadType(typeof(Modifiers));
+        Type TypeOfModifiers => typeofModifiers ??= ResolveRuntimeType(typeof(Modifiers));
 
-        Type TypeOfSourceFileAttribute => typeofSourceFileAttribute ??= LoadType(typeof(SourceFileAttribute));
+        Type TypeOfSourceFileAttribute => typeofSourceFileAttribute ??= ResolveRuntimeType(typeof(SourceFileAttribute));
 
-        Type TypeOfLineNumberTableAttribute => typeofLineNumberTableAttribute ??= LoadType(typeof(LineNumberTableAttribute));
+        Type TypeOfLineNumberTableAttribute => typeofLineNumberTableAttribute ??= ResolveRuntimeType(typeof(LineNumberTableAttribute));
 
 #endif
 
-        Type TypeOfRemappedClassAttribute => typeofRemappedClassAttribute ??= LoadType(typeof(RemappedClassAttribute));
+        Type TypeOfRemappedClassAttribute => typeofRemappedClassAttribute ??= ResolveRuntimeType(typeof(RemappedClassAttribute));
 
-        Type TypeOfRemappedTypeAttribute => typeofRemappedTypeAttribute ??= LoadType(typeof(RemappedTypeAttribute));
+        Type TypeOfRemappedTypeAttribute => typeofRemappedTypeAttribute ??= ResolveRuntimeType(typeof(RemappedTypeAttribute));
 
-        Type TypeOfModifiersAttribute => typeofModifiersAttribute ??= LoadType(typeof(ModifiersAttribute));
+        Type TypeOfModifiersAttribute => typeofModifiersAttribute ??= ResolveRuntimeType(typeof(ModifiersAttribute));
 
-        Type TypeOfRemappedInterfaceMethodAttribute => typeofRemappedInterfaceMethodAttribute ??= LoadType(typeof(RemappedInterfaceMethodAttribute));
+        Type TypeOfRemappedInterfaceMethodAttribute => typeofRemappedInterfaceMethodAttribute ??= ResolveRuntimeType(typeof(RemappedInterfaceMethodAttribute));
 
-        Type TypeOfNameSigAttribute => typeofNameSigAttribute ??= LoadType(typeof(NameSigAttribute));
+        Type TypeOfNameSigAttribute => typeofNameSigAttribute ??= ResolveRuntimeType(typeof(NameSigAttribute));
 
-        Type TypeOfJavaModuleAttribute => typeofJavaModuleAttribute ??= LoadType(typeof(JavaModuleAttribute));
+        Type TypeOfJavaModuleAttribute => typeofJavaModuleAttribute ??= ResolveRuntimeType(typeof(JavaModuleAttribute));
 
-        Type TypeOfSignatureAttribute => typeofSignatureAttribute ??= LoadType(typeof(SignatureAttribute));
+        Type TypeOfSignatureAttribute => typeofSignatureAttribute ??= ResolveRuntimeType(typeof(SignatureAttribute));
 
-        Type TypeOfInnerClassAttribute => typeofInnerClassAttribute ??= LoadType(typeof(InnerClassAttribute));
+        Type TypeOfInnerClassAttribute => typeofInnerClassAttribute ??= ResolveRuntimeType(typeof(InnerClassAttribute));
 
-        Type TypeOfImplementsAttribute => typeofImplementsAttribute ??= LoadType(typeof(ImplementsAttribute));
+        Type TypeOfImplementsAttribute => typeofImplementsAttribute ??= ResolveRuntimeType(typeof(ImplementsAttribute));
 
-        Type TypeOfGhostInterfaceAttribute => typeofGhostInterfaceAttribute ??= LoadType(typeof(GhostInterfaceAttribute));
+        Type TypeOfGhostInterfaceAttribute => typeofGhostInterfaceAttribute ??= ResolveRuntimeType(typeof(GhostInterfaceAttribute));
 
-        Type TypeOfExceptionIsUnsafeForMappingAttribute => typeofExceptionIsUnsafeForMappingAttribute ??= LoadType(typeof(ExceptionIsUnsafeForMappingAttribute));
+        Type TypeOfExceptionIsUnsafeForMappingAttribute => typeofExceptionIsUnsafeForMappingAttribute ??= ResolveRuntimeType(typeof(ExceptionIsUnsafeForMappingAttribute));
 
-        Type TypeOfThrowsAttribute => typeofThrowsAttribute ??= LoadType(typeof(ThrowsAttribute));
+        Type TypeOfThrowsAttribute => typeofThrowsAttribute ??= ResolveRuntimeType(typeof(ThrowsAttribute));
 
-        Type TypeOfHideFromJavaAttribute => typeofHideFromJavaAttribute ??= LoadType(typeof(HideFromJavaAttribute));
+        Type TypeOfHideFromJavaAttribute => typeofHideFromJavaAttribute ??= ResolveRuntimeType(typeof(HideFromJavaAttribute));
 
-        Type TypeOfHideFromJavaFlags => typeofHideFromJavaFlags ??= LoadType(typeof(HideFromJavaFlags));
+        Type TypeOfHideFromJavaFlags => typeofHideFromJavaFlags ??= ResolveRuntimeType(typeof(HideFromJavaFlags));
 
-        Type TypeOfNoPackagePrefixAttribute => typeofNoPackagePrefixAttribute ??= LoadType(typeof(NoPackagePrefixAttribute));
+        Type TypeOfNoPackagePrefixAttribute => typeofNoPackagePrefixAttribute ??= ResolveRuntimeType(typeof(NoPackagePrefixAttribute));
 
-        Type TypeOfAnnotationAttributeAttribute => typeofAnnotationAttributeAttribute ??= LoadType(typeof(AnnotationAttributeAttribute));
+        Type TypeOfAnnotationAttributeAttribute => typeofAnnotationAttributeAttribute ??= ResolveRuntimeType(typeof(AnnotationAttributeAttribute));
 
-        Type TypeOfNonNestedInnerClassAttribute => typeofNonNestedInnerClassAttribute ??= LoadType(typeof(NonNestedInnerClassAttribute));
+        Type TypeOfNonNestedInnerClassAttribute => typeofNonNestedInnerClassAttribute ??= ResolveRuntimeType(typeof(NonNestedInnerClassAttribute));
 
-        Type TypeOfNonNestedOuterClassAttribute => typeofNonNestedOuterClassAttribute ??= LoadType(typeof(NonNestedOuterClassAttribute));
+        Type TypeOfNonNestedOuterClassAttribute => typeofNonNestedOuterClassAttribute ??= ResolveRuntimeType(typeof(NonNestedOuterClassAttribute));
 
-        Type TypeOfEnclosingMethodAttribute => typeofEnclosingMethodAttribute ??= LoadType(typeof(EnclosingMethodAttribute));
+        Type TypeOfEnclosingMethodAttribute => typeofEnclosingMethodAttribute ??= ResolveRuntimeType(typeof(EnclosingMethodAttribute));
 
-        Type TypeOfMethodParametersAttribute => typeofMethodParametersAttribute ??= LoadType(typeof(MethodParametersAttribute));
+        Type TypeOfMethodParametersAttribute => typeofMethodParametersAttribute ??= ResolveRuntimeType(typeof(MethodParametersAttribute));
 
-        Type TypeOfRuntimeVisibleTypeAnnotationsAttribute => typeofRuntimeVisibleTypeAnnotationsAttribute ??= LoadType(typeof(RuntimeVisibleTypeAnnotationsAttribute));
+        Type TypeOfRuntimeVisibleTypeAnnotationsAttribute => typeofRuntimeVisibleTypeAnnotationsAttribute ??= ResolveRuntimeType(typeof(RuntimeVisibleTypeAnnotationsAttribute));
 
-        Type TypeOfConstantPoolAttribute => typeofConstantPoolAttribute ??= LoadType(typeof(ConstantPoolAttribute));
+        Type TypeOfConstantPoolAttribute => typeofConstantPoolAttribute ??= ResolveRuntimeType(typeof(ConstantPoolAttribute));
 
         Type TypeOfDebuggableAttribute => typeofDebuggableAttribute ??= context.Resolver.ResolveCoreType(typeof(DebuggableAttribute).FullName);
+
+        Type TypeOfAttributeUsageAttribute => typeofAttributeUsageAttribute ??= context.Resolver.ResolveCoreType(typeof(AttributeUsageAttribute).FullName);
 
         CustomAttributeBuilder HideFromJavaAttributeBuilder => hideFromJavaAttribute ??= new CustomAttributeBuilder(TypeOfHideFromJavaAttribute.GetConstructor(Type.EmptyTypes), Array.Empty<object>());
 
@@ -179,7 +183,7 @@ namespace IKVM.Runtime
         /// </summary>
         /// <param name="t"></param>
         /// <returns></returns>
-        Type LoadType(System.Type t)
+        Type ResolveRuntimeType(System.Type t)
         {
             return context.Resolver.ResolveRuntimeType(t.FullName);
         }
@@ -414,9 +418,11 @@ namespace IKVM.Runtime
             return editorBrowsableNever;
         }
 
-        internal void SetCompilerGenerated(TypeBuilder tb)
+        internal void SetAttributeUsage(TypeBuilder tb, AttributeTargets targets, bool allowMultiple = true)
         {
-            compilerGeneratedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(CompilerGeneratedAttribute).FullName).GetConstructor(Type.EmptyTypes), Array.Empty<object>());
+            var typeofAttributeTargets = context.Resolver.ResolveCoreType(typeof(AttributeTargets).FullName);
+            attributeUsageAttribute ??= TypeOfAttributeUsageAttribute.GetConstructor(new[] { typeofAttributeTargets });
+            var compilerGeneratedAttribute = new CustomAttributeBuilder(attributeUsageAttribute, new object[] { targets }, new[] { TypeOfAttributeUsageAttribute.GetProperty(nameof(AttributeUsageAttribute.AllowMultiple)) }, new[] { (object)allowMultiple });
             tb.SetCustomAttribute(compilerGeneratedAttribute);
         }
 
@@ -437,36 +443,26 @@ namespace IKVM.Runtime
 
         internal void SetDeprecatedAttribute(MethodBuilder mb)
         {
-            if (deprecatedAttribute == null)
-                deprecatedAttribute = new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
+            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
 
             mb.SetCustomAttribute(deprecatedAttribute);
         }
 
         internal void SetDeprecatedAttribute(TypeBuilder tb)
         {
-            if (deprecatedAttribute == null)
-            {
-                deprecatedAttribute = new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-            }
-
+            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
             tb.SetCustomAttribute(deprecatedAttribute);
         }
 
         internal void SetDeprecatedAttribute(FieldBuilder fb)
         {
-            if (deprecatedAttribute == null)
-                deprecatedAttribute = new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-
+            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
             fb.SetCustomAttribute(deprecatedAttribute);
         }
 
         internal void SetDeprecatedAttribute(PropertyBuilder pb)
         {
-            if (deprecatedAttribute == null)
-            {
-                deprecatedAttribute = new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-            }
+            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
             pb.SetCustomAttribute(deprecatedAttribute);
         }
 
@@ -499,6 +495,12 @@ namespace IKVM.Runtime
         }
 
 #endif // IMPORTER
+
+        internal void SetCompilerGenerated(TypeBuilder tb)
+        {
+            compilerGeneratedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(CompilerGeneratedAttribute).FullName).GetConstructor(Type.EmptyTypes), Array.Empty<object>());
+            tb.SetCustomAttribute(compilerGeneratedAttribute);
+        }
 
         internal void HideFromReflection(MethodBuilder mb)
         {
@@ -598,9 +600,7 @@ namespace IKVM.Runtime
             for (int i = 0; i < interfaces.Length; i++)
                 interfaces[i] = UnicodeUtil.EscapeInvalidSurrogates(ifaceWrappers[i].Name);
 
-            if (implementsAttribute == null)
-                implementsAttribute = TypeOfImplementsAttribute.GetConstructor(new Type[] { context.Resolver.ResolveCoreType(typeof(string).FullName).MakeArrayType() });
-
+            implementsAttribute ??= TypeOfImplementsAttribute.GetConstructor(new[] { context.Types.String.MakeArrayType() });
             typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(implementsAttribute, new object[] { interfaces }));
         }
 
@@ -812,7 +812,7 @@ namespace IKVM.Runtime
 
         internal void SetInnerClass(TypeBuilder typeBuilder, string innerClass, Modifiers modifiers)
         {
-            var argTypes = new Type[] { context.Types.String, TypeOfModifiers };
+            var argTypes = new[] { context.Types.String, TypeOfModifiers };
             var args = new object[] { UnicodeUtil.EscapeInvalidSurrogates(innerClass), modifiers };
             var ci = TypeOfInnerClassAttribute.GetConstructor(argTypes);
             var customAttributeBuilder = new CustomAttributeBuilder(ci, args);
@@ -837,27 +837,24 @@ namespace IKVM.Runtime
             ConstructorInfo con;
             if (writer.Count == 1)
             {
-                lineNumberTableAttribute2 ??= TypeOfLineNumberTableAttribute.GetConstructor(new Type[] { context.Types.UInt16 });
+                lineNumberTableAttribute2 ??= TypeOfLineNumberTableAttribute.GetConstructor(new[] { context.Types.UInt16 });
                 con = lineNumberTableAttribute2;
                 arg = (ushort)writer.LineNo;
             }
             else
             {
-                lineNumberTableAttribute1 ??= TypeOfLineNumberTableAttribute.GetConstructor(new Type[] { context.Resolver.ResolveCoreType(typeof(byte).FullName).MakeArrayType() });
+                lineNumberTableAttribute1 ??= TypeOfLineNumberTableAttribute.GetConstructor(new[] { context.Types.Byte.MakeArrayType() });
                 con = lineNumberTableAttribute1;
                 arg = writer.ToArray();
             }
+
             mb.SetCustomAttribute(new CustomAttributeBuilder(con, new object[] { arg }));
         }
 
         internal void SetEnclosingMethodAttribute(TypeBuilder tb, string className, string methodName, string methodSig)
         {
-            if (enclosingMethodAttribute == null)
-            {
-                enclosingMethodAttribute = TypeOfEnclosingMethodAttribute.GetConstructor(new Type[] { context.Types.String, context.Types.String, context.Types.String });
-            }
-            tb.SetCustomAttribute(new CustomAttributeBuilder(enclosingMethodAttribute,
-                new object[] { UnicodeUtil.EscapeInvalidSurrogates(className), UnicodeUtil.EscapeInvalidSurrogates(methodName), UnicodeUtil.EscapeInvalidSurrogates(methodSig) }));
+            enclosingMethodAttribute ??= TypeOfEnclosingMethodAttribute.GetConstructor(new Type[] { context.Types.String, context.Types.String, context.Types.String });
+            tb.SetCustomAttribute(new CustomAttributeBuilder(enclosingMethodAttribute, new object[] { UnicodeUtil.EscapeInvalidSurrogates(className), UnicodeUtil.EscapeInvalidSurrogates(methodName), UnicodeUtil.EscapeInvalidSurrogates(methodSig) }));
         }
 
         internal void SetSignatureAttribute(TypeBuilder tb, string signature)

--- a/src/IKVM.Runtime/AttributeHelper.cs
+++ b/src/IKVM.Runtime/AttributeHelper.cs
@@ -61,122 +61,123 @@ namespace IKVM.Runtime
 
         readonly RuntimeContext context;
 
-#if IMPORTER
+        Type typeOfModifiers;
+        Type typeOfSourceFileAttribute;
+        Type typeOfLineNumberTableAttribute;
+        ConstructorInfo implementsAttributeConstructor;
+        ConstructorInfo throwsAttributeConstructor;
+        ConstructorInfo sourceFileAttributeConstructor;
+        ConstructorInfo lineNumberTableAttributeConstructor1;
+        ConstructorInfo lineNumberTableAttributeConstructor2;
+        ConstructorInfo enclosingMethodAttributeConstructor;
+        ConstructorInfo signatureAttributeConstructor;
+        ConstructorInfo methodParametersAttributeConstructor;
+        ConstructorInfo runtimeVisibleTypeAnnotationsAttributeConstructor;
+        ConstructorInfo constantPoolAttributeConstructor;
+        ConstructorInfo nonNestedInnerClassAttributeConstructor;
+        ConstructorInfo nonNestedOuterClassAttributeConstructor;
+        CustomAttributeBuilder paramArrayAttributeBuilder;
+        CustomAttributeBuilder ghostInterfaceAttributeBuilder;
+        CustomAttributeBuilder deprecatedAttributeBuilder;
+        CustomAttributeBuilder editorBrowsableAttributeNeverBuilder;
 
-
-        Type typeofModifiers;
-        Type typeofSourceFileAttribute;
-        Type typeofLineNumberTableAttribute;
-        ConstructorInfo implementsAttribute;
-        ConstructorInfo throwsAttribute;
-        ConstructorInfo sourceFileAttribute;
-        ConstructorInfo lineNumberTableAttribute1;
-        ConstructorInfo lineNumberTableAttribute2;
-        ConstructorInfo enclosingMethodAttribute;
-        ConstructorInfo signatureAttribute;
-        ConstructorInfo methodParametersAttribute;
-        ConstructorInfo runtimeVisibleTypeAnnotationsAttribute;
-        ConstructorInfo constantPoolAttribute;
-        ConstructorInfo nonNestedInnerClassAttribute;
-        ConstructorInfo nonNestedOuterClassAttribute;
-        CustomAttributeBuilder paramArrayAttribute;
-        CustomAttributeBuilder ghostInterfaceAttribute;
-        CustomAttributeBuilder deprecatedAttribute;
-        CustomAttributeBuilder editorBrowsableNever;
-
-#endif
-
-        Type typeofRemappedClassAttribute;
-        Type typeofRemappedTypeAttribute;
-        Type typeofModifiersAttribute;
-        Type typeofRemappedInterfaceMethodAttribute;
-        Type typeofNameSigAttribute;
-        Type typeofJavaModuleAttribute;
-        Type typeofSignatureAttribute;
-        Type typeofInnerClassAttribute;
-        Type typeofImplementsAttribute;
-        Type typeofGhostInterfaceAttribute;
-        Type typeofExceptionIsUnsafeForMappingAttribute;
-        Type typeofThrowsAttribute;
-        Type typeofHideFromJavaAttribute;
-        Type typeofHideFromJavaFlags;
-        Type typeofNoPackagePrefixAttribute;
-        Type typeofAnnotationAttributeAttribute;
-        Type typeofNonNestedInnerClassAttribute;
-        Type typeofNonNestedOuterClassAttribute;
-        Type typeofEnclosingMethodAttribute;
-        Type typeofMethodParametersAttribute;
-        Type typeofRuntimeVisibleTypeAnnotationsAttribute;
-        Type typeofConstantPoolAttribute;
-        Type typeofDebuggableAttribute;
-        Type typeofAttributeUsageAttribute;
-        ConstructorInfo debuggableAttribute;
-        ConstructorInfo attributeUsageAttribute;
-        CustomAttributeBuilder hideFromJavaAttribute;
-        CustomAttributeBuilder hideFromReflection;
+        Type typeOfRemappedClassAttribute;
+        Type typeOfRemappedTypeAttribute;
+        Type typeOfModifiersAttribute;
+        Type typeOfRemappedInterfaceMethodAttribute;
+        Type typeOfNameSigAttribute;
+        Type typeOfJavaModuleAttribute;
+        Type typeOfSignatureAttribute;
+        Type typeOfInnerClassAttribute;
+        Type typeOfImplementsAttribute;
+        Type typeOfGhostInterfaceAttribute;
+        Type typeOfExceptionIsUnsafeForMappingAttribute;
+        Type typeOfThrowsAttribute;
+        Type typeOfHideFromJavaAttribute;
+        Type typeOfHideFromJavaFlags;
+        Type typeOfNoPackagePrefixAttribute;
+        Type typeOfAnnotationAttributeAttribute;
+        Type typeOfNonNestedInnerClassAttribute;
+        Type typeOfNonNestedOuterClassAttribute;
+        Type typeOfEnclosingMethodAttribute;
+        Type typeOfMethodParametersAttribute;
+        Type typeOfRuntimeVisibleTypeAnnotationsAttribute;
+        Type typeOfConstantPoolAttribute;
+        Type typeOfDebuggableAttribute;
+        Type typeOfAttributeUsageAttribute;
+        ConstructorInfo debuggableAttributeConstructor;
+        ConstructorInfo attributeUsageAttributeConstructor;
+        CustomAttributeBuilder hideFromJavaAttributeBuilder;
+        CustomAttributeBuilder hideFromReflectionBuilder;
         CustomAttributeBuilder compilerGeneratedAttribute;
 
-#if IMPORTER
+        Type TypeOfModifiers => typeOfModifiers ??= ResolveRuntimeType(typeof(Modifiers));
 
-        Type TypeOfModifiers => typeofModifiers ??= ResolveRuntimeType(typeof(Modifiers));
+        Type TypeOfSourceFileAttribute => typeOfSourceFileAttribute ??= ResolveRuntimeType(typeof(SourceFileAttribute));
 
-        Type TypeOfSourceFileAttribute => typeofSourceFileAttribute ??= ResolveRuntimeType(typeof(SourceFileAttribute));
+        Type TypeOfLineNumberTableAttribute => typeOfLineNumberTableAttribute ??= ResolveRuntimeType(typeof(LineNumberTableAttribute));
 
-        Type TypeOfLineNumberTableAttribute => typeofLineNumberTableAttribute ??= ResolveRuntimeType(typeof(LineNumberTableAttribute));
+        Type TypeOfRemappedClassAttribute => typeOfRemappedClassAttribute ??= ResolveRuntimeType(typeof(RemappedClassAttribute));
 
-#endif
+        Type TypeOfRemappedTypeAttribute => typeOfRemappedTypeAttribute ??= ResolveRuntimeType(typeof(RemappedTypeAttribute));
 
-        Type TypeOfRemappedClassAttribute => typeofRemappedClassAttribute ??= ResolveRuntimeType(typeof(RemappedClassAttribute));
+        Type TypeOfModifiersAttribute => typeOfModifiersAttribute ??= ResolveRuntimeType(typeof(ModifiersAttribute));
 
-        Type TypeOfRemappedTypeAttribute => typeofRemappedTypeAttribute ??= ResolveRuntimeType(typeof(RemappedTypeAttribute));
+        Type TypeOfRemappedInterfaceMethodAttribute => typeOfRemappedInterfaceMethodAttribute ??= ResolveRuntimeType(typeof(RemappedInterfaceMethodAttribute));
 
-        Type TypeOfModifiersAttribute => typeofModifiersAttribute ??= ResolveRuntimeType(typeof(ModifiersAttribute));
+        Type TypeOfNameSigAttribute => typeOfNameSigAttribute ??= ResolveRuntimeType(typeof(NameSigAttribute));
 
-        Type TypeOfRemappedInterfaceMethodAttribute => typeofRemappedInterfaceMethodAttribute ??= ResolveRuntimeType(typeof(RemappedInterfaceMethodAttribute));
+        Type TypeOfJavaModuleAttribute => typeOfJavaModuleAttribute ??= ResolveRuntimeType(typeof(JavaModuleAttribute));
 
-        Type TypeOfNameSigAttribute => typeofNameSigAttribute ??= ResolveRuntimeType(typeof(NameSigAttribute));
+        Type TypeOfSignatureAttribute => typeOfSignatureAttribute ??= ResolveRuntimeType(typeof(SignatureAttribute));
 
-        Type TypeOfJavaModuleAttribute => typeofJavaModuleAttribute ??= ResolveRuntimeType(typeof(JavaModuleAttribute));
+        Type TypeOfInnerClassAttribute => typeOfInnerClassAttribute ??= ResolveRuntimeType(typeof(InnerClassAttribute));
 
-        Type TypeOfSignatureAttribute => typeofSignatureAttribute ??= ResolveRuntimeType(typeof(SignatureAttribute));
+        Type TypeOfImplementsAttribute => typeOfImplementsAttribute ??= ResolveRuntimeType(typeof(ImplementsAttribute));
 
-        Type TypeOfInnerClassAttribute => typeofInnerClassAttribute ??= ResolveRuntimeType(typeof(InnerClassAttribute));
+        Type TypeOfGhostInterfaceAttribute => typeOfGhostInterfaceAttribute ??= ResolveRuntimeType(typeof(GhostInterfaceAttribute));
 
-        Type TypeOfImplementsAttribute => typeofImplementsAttribute ??= ResolveRuntimeType(typeof(ImplementsAttribute));
+        Type TypeOfExceptionIsUnsafeForMappingAttribute => typeOfExceptionIsUnsafeForMappingAttribute ??= ResolveRuntimeType(typeof(ExceptionIsUnsafeForMappingAttribute));
 
-        Type TypeOfGhostInterfaceAttribute => typeofGhostInterfaceAttribute ??= ResolveRuntimeType(typeof(GhostInterfaceAttribute));
+        Type TypeOfThrowsAttribute => typeOfThrowsAttribute ??= ResolveRuntimeType(typeof(ThrowsAttribute));
 
-        Type TypeOfExceptionIsUnsafeForMappingAttribute => typeofExceptionIsUnsafeForMappingAttribute ??= ResolveRuntimeType(typeof(ExceptionIsUnsafeForMappingAttribute));
+        Type TypeOfHideFromJavaAttribute => typeOfHideFromJavaAttribute ??= ResolveRuntimeType(typeof(HideFromJavaAttribute));
 
-        Type TypeOfThrowsAttribute => typeofThrowsAttribute ??= ResolveRuntimeType(typeof(ThrowsAttribute));
+        Type TypeOfHideFromJavaFlags => typeOfHideFromJavaFlags ??= ResolveRuntimeType(typeof(HideFromJavaFlags));
 
-        Type TypeOfHideFromJavaAttribute => typeofHideFromJavaAttribute ??= ResolveRuntimeType(typeof(HideFromJavaAttribute));
+        Type TypeOfNoPackagePrefixAttribute => typeOfNoPackagePrefixAttribute ??= ResolveRuntimeType(typeof(NoPackagePrefixAttribute));
 
-        Type TypeOfHideFromJavaFlags => typeofHideFromJavaFlags ??= ResolveRuntimeType(typeof(HideFromJavaFlags));
+        Type TypeOfAnnotationAttributeAttribute => typeOfAnnotationAttributeAttribute ??= ResolveRuntimeType(typeof(AnnotationAttributeAttribute));
 
-        Type TypeOfNoPackagePrefixAttribute => typeofNoPackagePrefixAttribute ??= ResolveRuntimeType(typeof(NoPackagePrefixAttribute));
+        Type TypeOfNonNestedInnerClassAttribute => typeOfNonNestedInnerClassAttribute ??= ResolveRuntimeType(typeof(NonNestedInnerClassAttribute));
 
-        Type TypeOfAnnotationAttributeAttribute => typeofAnnotationAttributeAttribute ??= ResolveRuntimeType(typeof(AnnotationAttributeAttribute));
+        Type TypeOfNonNestedOuterClassAttribute => typeOfNonNestedOuterClassAttribute ??= ResolveRuntimeType(typeof(NonNestedOuterClassAttribute));
 
-        Type TypeOfNonNestedInnerClassAttribute => typeofNonNestedInnerClassAttribute ??= ResolveRuntimeType(typeof(NonNestedInnerClassAttribute));
+        Type TypeOfEnclosingMethodAttribute => typeOfEnclosingMethodAttribute ??= ResolveRuntimeType(typeof(EnclosingMethodAttribute));
 
-        Type TypeOfNonNestedOuterClassAttribute => typeofNonNestedOuterClassAttribute ??= ResolveRuntimeType(typeof(NonNestedOuterClassAttribute));
+        Type TypeOfMethodParametersAttribute => typeOfMethodParametersAttribute ??= ResolveRuntimeType(typeof(MethodParametersAttribute));
 
-        Type TypeOfEnclosingMethodAttribute => typeofEnclosingMethodAttribute ??= ResolveRuntimeType(typeof(EnclosingMethodAttribute));
+        Type TypeOfRuntimeVisibleTypeAnnotationsAttribute => typeOfRuntimeVisibleTypeAnnotationsAttribute ??= ResolveRuntimeType(typeof(RuntimeVisibleTypeAnnotationsAttribute));
 
-        Type TypeOfMethodParametersAttribute => typeofMethodParametersAttribute ??= ResolveRuntimeType(typeof(MethodParametersAttribute));
+        Type TypeOfConstantPoolAttribute => typeOfConstantPoolAttribute ??= ResolveRuntimeType(typeof(ConstantPoolAttribute));
 
-        Type TypeOfRuntimeVisibleTypeAnnotationsAttribute => typeofRuntimeVisibleTypeAnnotationsAttribute ??= ResolveRuntimeType(typeof(RuntimeVisibleTypeAnnotationsAttribute));
+        Type TypeOfDebuggableAttribute => typeOfDebuggableAttribute ??= ResolveCoreType(typeof(DebuggableAttribute));
 
-        Type TypeOfConstantPoolAttribute => typeofConstantPoolAttribute ??= ResolveRuntimeType(typeof(ConstantPoolAttribute));
+        Type TypeOfAttributeUsageAttribute => typeOfAttributeUsageAttribute ??= ResolveCoreType(typeof(AttributeUsageAttribute));
 
-        Type TypeOfDebuggableAttribute => typeofDebuggableAttribute ??= context.Resolver.ResolveCoreType(typeof(DebuggableAttribute).FullName);
+        CustomAttributeBuilder HideFromJavaAttributeBuilder => hideFromJavaAttributeBuilder ??= new CustomAttributeBuilder(TypeOfHideFromJavaAttribute.GetConstructor(Type.EmptyTypes), Array.Empty<object>());
 
-        Type TypeOfAttributeUsageAttribute => typeofAttributeUsageAttribute ??= context.Resolver.ResolveCoreType(typeof(AttributeUsageAttribute).FullName);
+        CustomAttributeBuilder HideFromReflectionBuilder => hideFromReflectionBuilder ??= new CustomAttributeBuilder(TypeOfHideFromJavaAttribute.GetConstructor(new[] { TypeOfHideFromJavaFlags }), new object[] { HideFromJavaFlags.Reflection | HideFromJavaFlags.StackTrace | HideFromJavaFlags.StackWalk });
 
-        CustomAttributeBuilder HideFromJavaAttributeBuilder => hideFromJavaAttribute ??= new CustomAttributeBuilder(TypeOfHideFromJavaAttribute.GetConstructor(Type.EmptyTypes), Array.Empty<object>());
-
-        CustomAttributeBuilder HideFromReflectionBuilder => hideFromReflection ??= new CustomAttributeBuilder(TypeOfHideFromJavaAttribute.GetConstructor(new[] { TypeOfHideFromJavaFlags }), new object[] { HideFromJavaFlags.Reflection | HideFromJavaFlags.StackTrace | HideFromJavaFlags.StackWalk });
+        /// <summary>
+        /// Loads the given managed type from the core assembly.
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        Type ResolveCoreType(System.Type t)
+        {
+            return context.Resolver.ResolveCoreType(t.FullName);
+        }
 
         /// <summary>
         /// Loads the given managed type from the runtime assembly.
@@ -197,7 +198,8 @@ namespace IKVM.Runtime
             this.context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-#if IMPORTER
+
+#if IMPORTER || EXPORTER
 
         object ParseValue(RuntimeClassLoader loader, RuntimeJavaType tw, string val)
         {
@@ -298,18 +300,17 @@ namespace IKVM.Runtime
             for (int i = 0; i < twargs.Length; i++)
             {
                 argTypes[i] = twargs[i].TypeAsSignatureType;
-                RuntimeJavaType tw = twargs[i];
+
+                var tw = twargs[i];
                 if (tw == context.JavaBase.TypeOfJavaLangObject)
-                {
                     tw = loader.FieldTypeWrapperFromSig(attr.Params[i].Sig, LoadMode.Link);
-                }
+
                 if (tw.IsArray)
                 {
-                    Array arr = Array.CreateInstance(Type.__GetSystemType(Type.GetTypeCode(tw.ElementTypeWrapper.TypeAsArrayType)), attr.Params[i].Elements.Length);
+                    var arr = Array.CreateInstance(Type.__GetSystemType(Type.GetTypeCode(tw.ElementTypeWrapper.TypeAsArrayType)), attr.Params[i].Elements.Length);
                     for (int j = 0; j < arr.Length; j++)
-                    {
                         arr.SetValue(ParseValue(loader, tw.ElementTypeWrapper, attr.Params[i].Elements[j].Value), j);
-                    }
+
                     args[i] = arr;
                 }
                 else
@@ -321,10 +322,8 @@ namespace IKVM.Runtime
 
         CustomAttributeBuilder CreateCustomAttribute(RuntimeClassLoader loader, IKVM.Tools.Importer.MapXml.Attribute attr)
         {
-            // TODO add error handling
-            Type[] argTypes;
-            object[] args;
-            GetAttributeArgsAndTypes(loader, attr, out argTypes, out args);
+            GetAttributeArgsAndTypes(loader, attr, out var argTypes, out var args);
+
             if (attr.Type != null)
             {
                 var t = context.Resolver.ResolveCoreType(attr.Type);
@@ -346,9 +345,10 @@ namespace IKVM.Runtime
                 }
                 else
                 {
-                    namedProperties = new PropertyInfo[0];
-                    propertyValues = new object[0];
+                    namedProperties = Array.Empty<PropertyInfo>();
+                    propertyValues = Array.Empty<object>();
                 }
+
                 FieldInfo[] namedFields;
                 object[] fieldValues;
                 if (attr.Fields != null)
@@ -363,18 +363,19 @@ namespace IKVM.Runtime
                 }
                 else
                 {
-                    namedFields = new FieldInfo[0];
-                    fieldValues = new object[0];
+                    namedFields = Array.Empty<FieldInfo>();
+                    fieldValues = Array.Empty<object>();
                 }
+
                 return new CustomAttributeBuilder(ci, args, namedProperties, propertyValues, namedFields, fieldValues);
             }
             else
             {
                 if (attr.Properties != null)
-                {
                     throw new NotImplementedException("Setting property values on Java attributes is not implemented");
-                }
-                RuntimeJavaType t = loader.LoadClassByName(attr.Class);
+
+                var t = loader.LoadClassByName(attr.Class);
+
                 FieldInfo[] namedFields;
                 object[] fieldValues;
                 if (attr.Fields != null)
@@ -391,38 +392,38 @@ namespace IKVM.Runtime
                 }
                 else
                 {
-                    namedFields = new FieldInfo[0];
-                    fieldValues = new object[0];
+                    namedFields = Array.Empty<FieldInfo>();
+                    fieldValues = Array.Empty<object>();
                 }
+
                 var mw = t.GetMethodWrapper("<init>", attr.Sig, false);
                 if (mw == null)
-                {
                     throw new InvalidOperationException(string.Format("Constructor missing: {0}::<init>{1}", attr.Class, attr.Sig));
-                }
+
                 mw.Link();
-                ConstructorInfo ci = (mw.GetMethod() as ConstructorInfo) ?? ((MethodInfo)mw.GetMethod()).__AsConstructorInfo();
+                var ci = (mw.GetMethod() as ConstructorInfo) ?? ((MethodInfo)mw.GetMethod()).__AsConstructorInfo();
                 return new CustomAttributeBuilder(ci, args, namedFields, fieldValues);
             }
         }
 
         CustomAttributeBuilder GetEditorBrowsableNever()
         {
-            if (editorBrowsableNever == null)
+            if (editorBrowsableAttributeNeverBuilder == null)
             {
-                var typeofEditorBrowsableAttribute = context.Resolver.ResolveCoreType(typeof(EditorBrowsableAttribute).FullName);
-                var typeofEditorBrowsableState = context.Resolver.ResolveCoreType(typeof(EditorBrowsableState).FullName);
-                var ctor = (ConstructorInfo)typeofEditorBrowsableAttribute.__CreateMissingMethod(ConstructorInfo.ConstructorName, CallingConventions.Standard | CallingConventions.HasThis, null, default, new Type[] { typeofEditorBrowsableState }, null);
-                editorBrowsableNever = CustomAttributeBuilder.__FromBlob(ctor, new byte[] { 01, 00, 01, 00, 00, 00, 00, 00 });
+                var typeOfEditorBrowsableAttribute = context.Resolver.ResolveCoreType(typeof(EditorBrowsableAttribute).FullName);
+                var typeOfEditorBrowsableState = context.Resolver.ResolveCoreType(typeof(EditorBrowsableState).FullName);
+                var ctor = (ConstructorInfo)typeOfEditorBrowsableAttribute.__CreateMissingMethod(ConstructorInfo.ConstructorName, CallingConventions.Standard | CallingConventions.HasThis, null, default, new Type[] { typeOfEditorBrowsableState }, null);
+                editorBrowsableAttributeNeverBuilder = CustomAttributeBuilder.__FromBlob(ctor, new byte[] { 01, 00, 01, 00, 00, 00, 00, 00 });
             }
 
-            return editorBrowsableNever;
+            return editorBrowsableAttributeNeverBuilder;
         }
 
         internal void SetAttributeUsage(TypeBuilder tb, AttributeTargets targets, bool allowMultiple = true)
         {
             var typeofAttributeTargets = context.Resolver.ResolveCoreType(typeof(AttributeTargets).FullName);
-            attributeUsageAttribute ??= TypeOfAttributeUsageAttribute.GetConstructor(new[] { typeofAttributeTargets });
-            var compilerGeneratedAttribute = new CustomAttributeBuilder(attributeUsageAttribute, new object[] { targets }, new[] { TypeOfAttributeUsageAttribute.GetProperty(nameof(AttributeUsageAttribute.AllowMultiple)) }, new[] { (object)allowMultiple });
+            attributeUsageAttributeConstructor ??= TypeOfAttributeUsageAttribute.GetConstructor(new[] { typeofAttributeTargets });
+            var compilerGeneratedAttribute = new CustomAttributeBuilder(attributeUsageAttributeConstructor, new object[] { targets }, new[] { TypeOfAttributeUsageAttribute.GetProperty(nameof(AttributeUsageAttribute.AllowMultiple)) }, new[] { (object)allowMultiple });
             tb.SetCustomAttribute(compilerGeneratedAttribute);
         }
 
@@ -441,60 +442,59 @@ namespace IKVM.Runtime
             pb.SetCustomAttribute(GetEditorBrowsableNever());
         }
 
+#endif
+
         internal void SetDeprecatedAttribute(MethodBuilder mb)
         {
-            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-
-            mb.SetCustomAttribute(deprecatedAttribute);
+            deprecatedAttributeBuilder ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
+            mb.SetCustomAttribute(deprecatedAttributeBuilder);
         }
 
         internal void SetDeprecatedAttribute(TypeBuilder tb)
         {
-            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-            tb.SetCustomAttribute(deprecatedAttribute);
+            deprecatedAttributeBuilder ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
+            tb.SetCustomAttribute(deprecatedAttributeBuilder);
         }
 
         internal void SetDeprecatedAttribute(FieldBuilder fb)
         {
-            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-            fb.SetCustomAttribute(deprecatedAttribute);
+            deprecatedAttributeBuilder ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
+            fb.SetCustomAttribute(deprecatedAttributeBuilder);
         }
 
         internal void SetDeprecatedAttribute(PropertyBuilder pb)
         {
-            deprecatedAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-            pb.SetCustomAttribute(deprecatedAttribute);
+            deprecatedAttributeBuilder ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ObsoleteAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
+            pb.SetCustomAttribute(deprecatedAttributeBuilder);
         }
 
         internal void SetThrowsAttribute(MethodBuilder mb, string[] exceptions)
         {
             if (exceptions != null && exceptions.Length != 0)
             {
-                throwsAttribute ??= TypeOfThrowsAttribute.GetConstructor(new Type[] { context.Resolver.ResolveCoreType(typeof(string).FullName).MakeArrayType() });
+                throwsAttributeConstructor ??= TypeOfThrowsAttribute.GetConstructor(new Type[] { context.Resolver.ResolveCoreType(typeof(string).FullName).MakeArrayType() });
                 exceptions = UnicodeUtil.EscapeInvalidSurrogates(exceptions);
-                mb.SetCustomAttribute(new CustomAttributeBuilder(throwsAttribute, new object[] { exceptions }));
+                mb.SetCustomAttribute(new CustomAttributeBuilder(throwsAttributeConstructor, new object[] { exceptions }));
             }
         }
 
         internal void SetGhostInterface(TypeBuilder typeBuilder)
         {
-            ghostInterfaceAttribute ??= new CustomAttributeBuilder(TypeOfGhostInterfaceAttribute.GetConstructor(Type.EmptyTypes), new object[0]);
-            typeBuilder.SetCustomAttribute(ghostInterfaceAttribute);
+            ghostInterfaceAttributeBuilder ??= new CustomAttributeBuilder(TypeOfGhostInterfaceAttribute.GetConstructor(Type.EmptyTypes), new object[0]);
+            typeBuilder.SetCustomAttribute(ghostInterfaceAttributeBuilder);
         }
 
         internal void SetNonNestedInnerClass(TypeBuilder typeBuilder, string className)
         {
-            nonNestedInnerClassAttribute ??= TypeOfNonNestedInnerClassAttribute.GetConstructor(new Type[] { context.Types.String });
-            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(nonNestedInnerClassAttribute, new object[] { UnicodeUtil.EscapeInvalidSurrogates(className) }));
+            nonNestedInnerClassAttributeConstructor ??= TypeOfNonNestedInnerClassAttribute.GetConstructor(new Type[] { context.Types.String });
+            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(nonNestedInnerClassAttributeConstructor, new object[] { UnicodeUtil.EscapeInvalidSurrogates(className) }));
         }
 
         internal void SetNonNestedOuterClass(TypeBuilder typeBuilder, string className)
         {
-            nonNestedOuterClassAttribute ??= TypeOfNonNestedOuterClassAttribute.GetConstructor(new Type[] { context.Types.String });
-            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(nonNestedOuterClassAttribute, new object[] { UnicodeUtil.EscapeInvalidSurrogates(className) }));
+            nonNestedOuterClassAttributeConstructor ??= TypeOfNonNestedOuterClassAttribute.GetConstructor(new Type[] { context.Types.String });
+            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(nonNestedOuterClassAttributeConstructor, new object[] { UnicodeUtil.EscapeInvalidSurrogates(className) }));
         }
-
-#endif // IMPORTER
 
         internal void SetCompilerGenerated(TypeBuilder tb)
         {
@@ -529,8 +529,7 @@ namespace IKVM.Runtime
 
         internal void HideFromJava(MethodBuilder mb, HideFromJavaFlags flags)
         {
-            CustomAttributeBuilder cab = new CustomAttributeBuilder(TypeOfHideFromJavaAttribute.GetConstructor(new Type[] { TypeOfHideFromJavaFlags }), new object[] { flags });
-            mb.SetCustomAttribute(cab);
+            mb.SetCustomAttribute(new CustomAttributeBuilder(TypeOfHideFromJavaAttribute.GetConstructor(new Type[] { TypeOfHideFromJavaFlags }), new object[] { flags }));
         }
 
         internal void HideFromJava(FieldBuilder fb)
@@ -538,14 +537,10 @@ namespace IKVM.Runtime
             fb.SetCustomAttribute(HideFromJavaAttributeBuilder);
         }
 
-#if IMPORTER
-
         internal void HideFromJava(PropertyBuilder pb)
         {
             pb.SetCustomAttribute(HideFromJavaAttributeBuilder);
         }
-
-#endif
 
         internal bool IsHideFromJava(Type type)
         {
@@ -573,7 +568,7 @@ namespace IKVM.Runtime
 
 #if !IMPORTER && !EXPORTER
 
-            var attr = mi.GetCustomAttributes(typeofHideFromJavaAttribute, false);
+            var attr = mi.GetCustomAttributes(typeOfHideFromJavaAttribute, false);
             if (attr.Length == 1)
                 return ((HideFromJavaAttribute)attr[0]).Flags;
 
@@ -592,19 +587,15 @@ namespace IKVM.Runtime
             return HideFromJavaFlags.None;
         }
 
-#if IMPORTER
-
         internal void SetImplementsAttribute(TypeBuilder typeBuilder, RuntimeJavaType[] ifaceWrappers)
         {
             var interfaces = new string[ifaceWrappers.Length];
             for (int i = 0; i < interfaces.Length; i++)
                 interfaces[i] = UnicodeUtil.EscapeInvalidSurrogates(ifaceWrappers[i].Name);
 
-            implementsAttribute ??= TypeOfImplementsAttribute.GetConstructor(new[] { context.Types.String.MakeArrayType() });
-            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(implementsAttribute, new object[] { interfaces }));
+            implementsAttributeConstructor ??= TypeOfImplementsAttribute.GetConstructor(new[] { context.Types.String.MakeArrayType() });
+            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(implementsAttributeConstructor, new object[] { interfaces }));
         }
-
-#endif
 
         internal bool IsGhostInterface(Type type)
         {
@@ -754,11 +745,9 @@ namespace IKVM.Runtime
 
         internal void SetDebuggingModes(AssemblyBuilder assemblyBuilder, DebuggableAttribute.DebuggingModes modes)
         {
-            debuggableAttribute ??= TypeOfDebuggableAttribute.GetConstructor(new[] { TypeOfDebuggableAttribute.GetNestedType(nameof(DebuggableAttribute.DebuggingModes)) });
-            assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(debuggableAttribute, new object[] { modes }));
+            debuggableAttributeConstructor ??= TypeOfDebuggableAttribute.GetConstructor(new[] { TypeOfDebuggableAttribute.GetNestedType(nameof(DebuggableAttribute.DebuggingModes)) });
+            assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(debuggableAttributeConstructor, new object[] { modes }));
         }
-
-#if IMPORTER
 
         internal void SetModifiers(MethodBuilder mb, Modifiers modifiers, bool isInternal)
         {
@@ -821,14 +810,14 @@ namespace IKVM.Runtime
 
         internal void SetSourceFile(TypeBuilder typeBuilder, string filename)
         {
-            sourceFileAttribute ??= TypeOfSourceFileAttribute.GetConstructor(new Type[] { context.Types.String });
-            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(sourceFileAttribute, new object[] { filename }));
+            sourceFileAttributeConstructor ??= TypeOfSourceFileAttribute.GetConstructor(new Type[] { context.Types.String });
+            typeBuilder.SetCustomAttribute(new CustomAttributeBuilder(sourceFileAttributeConstructor, new object[] { filename }));
         }
 
         internal void SetSourceFile(ModuleBuilder moduleBuilder, string filename)
         {
-            sourceFileAttribute ??= TypeOfSourceFileAttribute.GetConstructor(new Type[] { context.Types.String });
-            moduleBuilder.SetCustomAttribute(new CustomAttributeBuilder(sourceFileAttribute, new object[] { filename }));
+            sourceFileAttributeConstructor ??= TypeOfSourceFileAttribute.GetConstructor(new Type[] { context.Types.String });
+            moduleBuilder.SetCustomAttribute(new CustomAttributeBuilder(sourceFileAttributeConstructor, new object[] { filename }));
         }
 
         internal void SetLineNumberTable(MethodBuilder mb, IKVM.Attributes.LineNumberTableAttribute.LineNumberWriter writer)
@@ -837,14 +826,14 @@ namespace IKVM.Runtime
             ConstructorInfo con;
             if (writer.Count == 1)
             {
-                lineNumberTableAttribute2 ??= TypeOfLineNumberTableAttribute.GetConstructor(new[] { context.Types.UInt16 });
-                con = lineNumberTableAttribute2;
+                lineNumberTableAttributeConstructor2 ??= TypeOfLineNumberTableAttribute.GetConstructor(new[] { context.Types.UInt16 });
+                con = lineNumberTableAttributeConstructor2;
                 arg = (ushort)writer.LineNo;
             }
             else
             {
-                lineNumberTableAttribute1 ??= TypeOfLineNumberTableAttribute.GetConstructor(new[] { context.Types.Byte.MakeArrayType() });
-                con = lineNumberTableAttribute1;
+                lineNumberTableAttributeConstructor1 ??= TypeOfLineNumberTableAttribute.GetConstructor(new[] { context.Types.Byte.MakeArrayType() });
+                con = lineNumberTableAttributeConstructor1;
                 arg = writer.ToArray();
             }
 
@@ -853,32 +842,32 @@ namespace IKVM.Runtime
 
         internal void SetEnclosingMethodAttribute(TypeBuilder tb, string className, string methodName, string methodSig)
         {
-            enclosingMethodAttribute ??= TypeOfEnclosingMethodAttribute.GetConstructor(new Type[] { context.Types.String, context.Types.String, context.Types.String });
-            tb.SetCustomAttribute(new CustomAttributeBuilder(enclosingMethodAttribute, new object[] { UnicodeUtil.EscapeInvalidSurrogates(className), UnicodeUtil.EscapeInvalidSurrogates(methodName), UnicodeUtil.EscapeInvalidSurrogates(methodSig) }));
+            enclosingMethodAttributeConstructor ??= TypeOfEnclosingMethodAttribute.GetConstructor(new Type[] { context.Types.String, context.Types.String, context.Types.String });
+            tb.SetCustomAttribute(new CustomAttributeBuilder(enclosingMethodAttributeConstructor, new object[] { UnicodeUtil.EscapeInvalidSurrogates(className), UnicodeUtil.EscapeInvalidSurrogates(methodName), UnicodeUtil.EscapeInvalidSurrogates(methodSig) }));
         }
 
         internal void SetSignatureAttribute(TypeBuilder tb, string signature)
         {
-            signatureAttribute ??= TypeOfSignatureAttribute.GetConstructor(new Type[] { context.Types.String });
-            tb.SetCustomAttribute(new CustomAttributeBuilder(signatureAttribute, new object[] { UnicodeUtil.EscapeInvalidSurrogates(signature) }));
+            signatureAttributeConstructor ??= TypeOfSignatureAttribute.GetConstructor(new Type[] { context.Types.String });
+            tb.SetCustomAttribute(new CustomAttributeBuilder(signatureAttributeConstructor, new object[] { UnicodeUtil.EscapeInvalidSurrogates(signature) }));
         }
 
         internal void SetSignatureAttribute(FieldBuilder fb, string signature)
         {
-            signatureAttribute ??= TypeOfSignatureAttribute.GetConstructor(new Type[] { context.Types.String });
-            fb.SetCustomAttribute(new CustomAttributeBuilder(signatureAttribute, new object[] { UnicodeUtil.EscapeInvalidSurrogates(signature) }));
+            signatureAttributeConstructor ??= TypeOfSignatureAttribute.GetConstructor(new Type[] { context.Types.String });
+            fb.SetCustomAttribute(new CustomAttributeBuilder(signatureAttributeConstructor, new object[] { UnicodeUtil.EscapeInvalidSurrogates(signature) }));
         }
 
         internal void SetSignatureAttribute(MethodBuilder mb, string signature)
         {
-            signatureAttribute ??= TypeOfSignatureAttribute.GetConstructor(new Type[] { context.Types.String });
-            mb.SetCustomAttribute(new CustomAttributeBuilder(signatureAttribute, new object[] { UnicodeUtil.EscapeInvalidSurrogates(signature) }));
+            signatureAttributeConstructor ??= TypeOfSignatureAttribute.GetConstructor(new Type[] { context.Types.String });
+            mb.SetCustomAttribute(new CustomAttributeBuilder(signatureAttributeConstructor, new object[] { UnicodeUtil.EscapeInvalidSurrogates(signature) }));
         }
 
         internal void SetMethodParametersAttribute(MethodBuilder mb, Modifiers[] modifiers)
         {
-            methodParametersAttribute ??= TypeOfMethodParametersAttribute.GetConstructor(new Type[] { TypeOfModifiers.MakeArrayType() });
-            mb.SetCustomAttribute(new CustomAttributeBuilder(methodParametersAttribute, new object[] { modifiers }));
+            methodParametersAttributeConstructor ??= TypeOfMethodParametersAttribute.GetConstructor(new Type[] { TypeOfModifiers.MakeArrayType() });
+            mb.SetCustomAttribute(new CustomAttributeBuilder(methodParametersAttributeConstructor, new object[] { modifiers }));
         }
 
         internal void SetRuntimeVisibleTypeAnnotationsAttribute(TypeBuilder tb, IReadOnlyList<TypeAnnotationReader> data)
@@ -889,8 +878,8 @@ namespace IKVM.Runtime
             if (r.TryWrite(ref w) == false)
                 throw new InternalException();
 
-            runtimeVisibleTypeAnnotationsAttribute ??= TypeOfRuntimeVisibleTypeAnnotationsAttribute.GetConstructor(new Type[] { context.Types.Byte.MakeArrayType() });
-            tb.SetCustomAttribute(new CustomAttributeBuilder(runtimeVisibleTypeAnnotationsAttribute, new object[] { m }));
+            runtimeVisibleTypeAnnotationsAttributeConstructor ??= TypeOfRuntimeVisibleTypeAnnotationsAttribute.GetConstructor(new Type[] { context.Types.Byte.MakeArrayType() });
+            tb.SetCustomAttribute(new CustomAttributeBuilder(runtimeVisibleTypeAnnotationsAttributeConstructor, new object[] { m }));
         }
 
         internal void SetRuntimeVisibleTypeAnnotationsAttribute(FieldBuilder fb, IReadOnlyList<TypeAnnotationReader> data)
@@ -901,8 +890,8 @@ namespace IKVM.Runtime
             if (r.TryWrite(ref w) == false)
                 throw new InternalException();
 
-            runtimeVisibleTypeAnnotationsAttribute ??= TypeOfRuntimeVisibleTypeAnnotationsAttribute.GetConstructor(new Type[] { context.Types.Byte.MakeArrayType() });
-            fb.SetCustomAttribute(new CustomAttributeBuilder(runtimeVisibleTypeAnnotationsAttribute, new object[] { m }));
+            runtimeVisibleTypeAnnotationsAttributeConstructor ??= TypeOfRuntimeVisibleTypeAnnotationsAttribute.GetConstructor(new Type[] { context.Types.Byte.MakeArrayType() });
+            fb.SetCustomAttribute(new CustomAttributeBuilder(runtimeVisibleTypeAnnotationsAttributeConstructor, new object[] { m }));
         }
 
         internal void SetRuntimeVisibleTypeAnnotationsAttribute(MethodBuilder mb, IReadOnlyList<TypeAnnotationReader> data)
@@ -913,23 +902,21 @@ namespace IKVM.Runtime
             if (r.TryWrite(ref w) == false)
                 throw new InternalException();
 
-            runtimeVisibleTypeAnnotationsAttribute ??= TypeOfRuntimeVisibleTypeAnnotationsAttribute.GetConstructor(new Type[] { context.Types.Byte.MakeArrayType() });
-            mb.SetCustomAttribute(new CustomAttributeBuilder(runtimeVisibleTypeAnnotationsAttribute, new object[] { m }));
+            runtimeVisibleTypeAnnotationsAttributeConstructor ??= TypeOfRuntimeVisibleTypeAnnotationsAttribute.GetConstructor(new Type[] { context.Types.Byte.MakeArrayType() });
+            mb.SetCustomAttribute(new CustomAttributeBuilder(runtimeVisibleTypeAnnotationsAttributeConstructor, new object[] { m }));
         }
 
         internal void SetConstantPoolAttribute(TypeBuilder tb, object[] constantPool)
         {
-            constantPoolAttribute ??= TypeOfConstantPoolAttribute.GetConstructor(new Type[] { context.Types.Object.MakeArrayType() });
-            tb.SetCustomAttribute(new CustomAttributeBuilder(constantPoolAttribute, new object[] { constantPool }));
+            constantPoolAttributeConstructor ??= TypeOfConstantPoolAttribute.GetConstructor(new Type[] { context.Types.Object.MakeArrayType() });
+            tb.SetCustomAttribute(new CustomAttributeBuilder(constantPoolAttributeConstructor, new object[] { constantPool }));
         }
 
         internal void SetParamArrayAttribute(ParameterBuilder pb)
         {
-            paramArrayAttribute ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ParamArrayAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
-            pb.SetCustomAttribute(paramArrayAttribute);
+            paramArrayAttributeBuilder ??= new CustomAttributeBuilder(context.Resolver.ResolveCoreType(typeof(ParamArrayAttribute).FullName).GetConstructor(Type.EmptyTypes), new object[0]);
+            pb.SetCustomAttribute(paramArrayAttributeBuilder);
         }
-
-#endif  // IMPORTER
 
         internal NameSigAttribute GetNameSig(MemberInfo member)
         {
@@ -1254,8 +1241,6 @@ namespace IKVM.Runtime
 #endif
         }
 
-#if IMPORTER
-
         internal void SetRemappedClass(AssemblyBuilder assemblyBuilder, string name, Type shadowType)
         {
             var remappedClassAttribute = TypeOfRemappedClassAttribute.GetConstructor(new Type[] { context.Types.String, context.Types.Type });
@@ -1270,7 +1255,7 @@ namespace IKVM.Runtime
 
         internal void SetRemappedInterfaceMethod(TypeBuilder typeBuilder, string name, string mappedTo, string[] throws)
         {
-            var cab = new CustomAttributeBuilder(TypeOfRemappedInterfaceMethodAttribute.GetConstructor(new Type[] { context.Types.String, context.Types.String, context.Types.String.MakeArrayType() }), new object[] { name, mappedTo, throws });
+            var cab = new CustomAttributeBuilder(TypeOfRemappedInterfaceMethodAttribute.GetConstructor(new[] { context.Types.String, context.Types.String, context.Types.String.MakeArrayType() }), new object[] { name, mappedTo, throws });
             typeBuilder.SetCustomAttribute(cab);
         }
 
@@ -1280,12 +1265,10 @@ namespace IKVM.Runtime
             typeBuilder.SetCustomAttribute(cab);
         }
 
-#endif
-
         internal void SetRuntimeCompatibilityAttribute(AssemblyBuilder assemblyBuilder)
         {
             var runtimeCompatibilityAttribute = context.Resolver.ResolveCoreType(typeof(RuntimeCompatibilityAttribute).FullName);
-            assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(runtimeCompatibilityAttribute.GetConstructor(Type.EmptyTypes), Array.Empty<object>(), new PropertyInfo[] { runtimeCompatibilityAttribute.GetProperty("WrapNonExceptionThrows") }, new object[] { true }, Array.Empty<FieldInfo>(), Array.Empty<object>()));
+            assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(runtimeCompatibilityAttribute.GetConstructor(Type.EmptyTypes), Array.Empty<object>(), new[] { runtimeCompatibilityAttribute.GetProperty("WrapNonExceptionThrows") }, new object[] { true }, Array.Empty<FieldInfo>(), Array.Empty<object>()));
         }
 
         internal void SetInternalsVisibleToAttribute(AssemblyBuilder assemblyBuilder, string assemblyName)

--- a/src/IKVM.Runtime/DynamicClassLoader.cs
+++ b/src/IKVM.Runtime/DynamicClassLoader.cs
@@ -130,6 +130,7 @@ namespace IKVM.Runtime
             if (loader is RuntimeAssemblyClassLoader acl)
             {
                 var name = acl.MainAssembly.GetName().Name + context.Options.DynamicAssemblySuffixAndPublicKey;
+
                 foreach (var attr in acl.MainAssembly.GetCustomAttributes<InternalsVisibleToAttribute>())
                 {
                     if (attr.AssemblyName == name)
@@ -546,7 +547,7 @@ namespace IKVM.Runtime
             var moduleBuilder = assemblyBuilder.DefineDynamicModule(name.Name);
 #endif
 
-            moduleBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(IKVM.Attributes.JavaModuleAttribute).GetConstructor(Type.EmptyTypes), new object[0]));
+            moduleBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(IKVM.Attributes.JavaModuleAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>()));
             return moduleBuilder;
         }
 

--- a/src/IKVM.Runtime/DynamicClassLoader.cs
+++ b/src/IKVM.Runtime/DynamicClassLoader.cs
@@ -513,7 +513,7 @@ namespace IKVM.Runtime
 
         public static ModuleBuilder CreateModuleBuilder(RuntimeContext context)
         {
-            AssemblyName name = new AssemblyName();
+            var name = new AssemblyName();
             name.Name = "ikvm_dynamic_assembly__" + (uint)Environment.TickCount;
             return CreateModuleBuilder(context, name);
         }
@@ -523,7 +523,7 @@ namespace IKVM.Runtime
             var now = DateTime.Now;
             name.Version = new Version(now.Year, (now.Month * 100) + now.Day, (now.Hour * 100) + now.Minute, (now.Second * 1000) + now.Millisecond);
             var attribs = new List<CustomAttributeBuilder>();
-            AssemblyBuilderAccess access = AssemblyBuilderAccess.Run;
+            var access = AssemblyBuilderAccess.Run;
 
 #if NETFRAMEWORK
             if (!AppDomain.CurrentDomain.IsFullyTrusted)

--- a/src/IKVM.Runtime/RuntimeJavaType.cs
+++ b/src/IKVM.Runtime/RuntimeJavaType.cs
@@ -883,20 +883,20 @@ namespace IKVM.Runtime
             return GetClassLoader().InternalsVisibleToImpl(this, wrapper);
         }
 
-        internal virtual bool IsPackageAccessibleFrom(RuntimeJavaType wrapper)
+        internal virtual bool IsPackageAccessibleFrom(RuntimeJavaType other)
         {
-            if (MatchingPackageNames(name, wrapper.name))
+            if (MatchingPackageNames(name, other.name))
             {
 #if IMPORTER
                 if (GetClassLoader() is CompilerClassLoader ccl)
                 {
                     // this is a hack for multi target -sharedclassloader compilation
                     // (during compilation we have multiple CompilerClassLoader instances to represent the single shared runtime class loader)
-                    return ccl.IsEquivalentTo(wrapper.GetClassLoader());
+                    return ccl.IsEquivalentTo(other.GetClassLoader());
                 }
 #endif
 
-                return GetClassLoader() == wrapper.GetClassLoader();
+                return GetClassLoader() == other.GetClassLoader();
             }
             else
             {

--- a/src/IKVM.Runtime/RuntimeJavaType.cs
+++ b/src/IKVM.Runtime/RuntimeJavaType.cs
@@ -867,11 +867,15 @@ namespace IKVM.Runtime
         internal virtual string SigName => "L" + Name + ";";
 
         // returns true iff wrapper is allowed to access us
-        internal bool IsAccessibleFrom(RuntimeJavaType wrapper)
+
+        /// <summary>
+        /// Returns <c>true</c> if the specified type is able to access us.
+        /// </summary>
+        /// <param name="wrapper"></param>
+        /// <returns></returns>
+        internal bool IsAccessibleFrom(RuntimeJavaType other)
         {
-            return IsPublic
-                || (IsInternal && InternalsVisibleTo(wrapper))
-                || IsPackageAccessibleFrom(wrapper);
+            return IsPublic || (IsInternal && InternalsVisibleTo(other)) || IsPackageAccessibleFrom(other);
         }
 
         internal bool InternalsVisibleTo(RuntimeJavaType wrapper)
@@ -884,14 +888,14 @@ namespace IKVM.Runtime
             if (MatchingPackageNames(name, wrapper.name))
             {
 #if IMPORTER
-                CompilerClassLoader ccl = GetClassLoader() as CompilerClassLoader;
-                if (ccl != null)
+                if (GetClassLoader() is CompilerClassLoader ccl)
                 {
                     // this is a hack for multi target -sharedclassloader compilation
                     // (during compilation we have multiple CompilerClassLoader instances to represent the single shared runtime class loader)
                     return ccl.IsEquivalentTo(wrapper.GetClassLoader());
                 }
 #endif
+
                 return GetClassLoader() == wrapper.GetClassLoader();
             }
             else

--- a/src/IKVM.Runtime/UnicodeUtil.cs
+++ b/src/IKVM.Runtime/UnicodeUtil.cs
@@ -61,6 +61,7 @@ namespace IKVM.Runtime
                     }
                 }
             }
+
             return str;
         }
 

--- a/src/IKVM.Tools.Importer.Tests/IkvmImporterTests.cs
+++ b/src/IKVM.Tools.Importer.Tests/IkvmImporterTests.cs
@@ -68,6 +68,7 @@ namespace IKVM.Tools.Importer.Tests
             File.Exists(asm).Should().BeTrue();
             new FileInfo(asm).Length.Should().BeGreaterThanOrEqualTo(128);
         }
+
     }
 
 }

--- a/src/IKVM.Tools.Importer/CompilerClassLoader.cs
+++ b/src/IKVM.Tools.Importer/CompilerClassLoader.cs
@@ -571,10 +571,9 @@ namespace IKVM.Tools.Importer
                 }
             }
 
-            // assemblies should have access to the internals of their referenced assemblies
             if (targetIsModule == false)
             {
-                // add the IgnoresAccessChecksToAttribute
+                // add IgnoresAccessChecksToAttribute internal type
                 var iactBuilder = mb.DefineType("System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute", TypeAttributes.Class | TypeAttributes.Sealed, Context.Types.Attribute);
                 iactBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, new[] { Context.Types.String });
                 Context.AttributeHelper.SetAttributeUsage(iactBuilder, AttributeTargets.Assembly, true);


### PR DESCRIPTION
… their references. The idea here is to solve the package-private issue. Since Java allows package-private access between JARs, and IKVM generally emits a different assembly per-JAR, we need a way to allow these across. One options was to change pacakge-private to public. This solution however might work.