### PR TITLE
Generate JDK source and data

### DIFF
--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -671,7 +671,7 @@ jobs:
                 "--blame",
                 "--blame-crash",
                 "--blame-hang",
-                "--blame-hang-timeout", "60m",
+                "--blame-hang-timeout", "120m",
                 "--blame-hang-dump-type", "full",
                 "-v:diag",
                 "--results-directory", "TestResults",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -103,10 +103,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/IKVM.refs.targets
+++ b/IKVM.refs.targets
@@ -33,14 +33,14 @@
             <OutputItemType>IkvmJavaItem</OutputItemType>
             <IkvmJavaRuntimeIdentifier>win</IkvmJavaRuntimeIdentifier>
         </ProjectReference>
-        <ProjectReference Include="$(MSBuildThisFileDirectory)src\IKVM.Java.runtime.linux\IKVM.Java.runtime.linux.csproj" Condition="$(_EnabledRuntimes.Contains(';linux-'))">
+        <ProjectReference Include="$(MSBuildThisFileDirectory)src\IKVM.Java.runtime.linux\IKVM.Java.runtime.linux.csproj" Condition="$(_EnabledRuntimes.Contains(';linux-')) And $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))">
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
             <Private>False</Private>
             <PrivateAssets>all</PrivateAssets>
             <OutputItemType>IkvmJavaItem</OutputItemType>
             <IkvmJavaRuntimeIdentifier>linux</IkvmJavaRuntimeIdentifier>
         </ProjectReference>
-        <ProjectReference Include="$(MSBuildThisFileDirectory)src\IKVM.Java.runtime.osx\IKVM.Java.runtime.osx.csproj" Condition="$(_EnabledRuntimes.Contains(';osx-'))">
+        <ProjectReference Include="$(MSBuildThisFileDirectory)src\IKVM.Java.runtime.osx\IKVM.Java.runtime.osx.csproj" Condition="$(_EnabledRuntimes.Contains(';osx-')) And $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))">
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
             <Private>False</Private>
             <PrivateAssets>all</PrivateAssets>

--- a/src/IKVM.Image/IKVM.Image.csproj
+++ b/src/IKVM.Image/IKVM.Image.csproj
@@ -54,11 +54,6 @@
         <IkvmImageItem Include="$(OpenJdkDir)jdk\src\share\lib\hijrah-config-umalqura.properties" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\%(Filename)%(Extension)" />
         <IkvmImageItem Include="$(OpenJdkDir)jdk\src\share\lib\cmm\lcms\*.pf" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\cmm\%(Filename)%(Extension)" />
         <IkvmImageItem Include="$(OpenJdkDir)jdk\src\share\lib\security\java.policy" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\security\java.policy" />
-        <IkvmImageItem Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\lib\security\blacklisted.certs" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\security\blacklisted.certs" />
-        <IkvmImageItem Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\lib\security\policy\limited\local_policy.jar" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\security\policy\limited\local_policy.jar" />
-        <IkvmImageItem Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\lib\security\policy\limited\US_export_policy.jar" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\security\policy\limited\US_export_policy.jar" />
-        <IkvmImageItem Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\lib\security\policy\unlimited\local_policy.jar" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\security\policy\unlimited\local_policy.jar" />
-        <IkvmImageItem Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\lib\security\policy\unlimited\US_export_policy.jar" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\security\policy\unlimited\US_export_policy.jar" />
         <IkvmImageItem Include="$(OpenJdkDir)jdk\src\share\lib\sound.properties" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\%(Filename)%(Extension)" />
         <IkvmImageItem Include="$(OpenJdkDir)jdk\src\share\lib\net.properties" TargetFramework="any" RuntimeIdentifier="any" ImagePath="lib\%(Filename)%(Extension)" />
     </ItemGroup>
@@ -139,6 +134,128 @@
             GenerateTZDB;
             GenerateCurrencyData;
             GenerateCacerts;
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <BlacklistedCertsSrc>$(OpenJdkDir)jdk\src\share\lib\security\blacklisted.certs</BlacklistedCertsSrc>
+        <BlacklistedCertsDst>$(IntermediateOutputPath)blacklisted.certs</BlacklistedCertsDst>
+    </PropertyGroup>
+
+    <Target Name="GenerateBlacklistedCerts" Inputs="$(MSBuildThisFileFullPath);$(BlacklistedCertsSrc)" Outputs="$(BlacklistedCertsDst)">
+        <Copy SourceFiles="$(BlacklistedCertsSrc)" DestinationFiles="$(BlacklistedCertsDst)" />
+
+        <ItemGroup>
+            <IkvmImageItem Include="$(BlacklistedCertsDst)" ImagePath="lib\security\blacklisted.certs" TargetFramework="any" RuntimeIdentifier="any" />
+            <FileWrites Include="$(BlacklistedCertsDst)" />
+        </ItemGroup>
+    </Target>
+
+    <PropertyGroup>
+        <GenerateDependsOn>
+            GenerateBlacklistedCerts;
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <USExportPolicyArchive>$(IntermediateOutputPath)US_export_policy.jar</USExportPolicyArchive>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <USExportPolicyFiles Include="$(OpenJdkDir)jdk\make\data\cryptopolicy\unlimited\default_local.policy" />
+    </ItemGroup>
+
+    <Target Name="GenerateUSExportPolicy" DependsOnTargets="ResolveJar" Inputs="$(MSBuildThisFileFullPath);$(OpenJdkDir)jdk\make\data\cryptopolicy\unlimited\default_US_export.policy" Outputs="$(USExportPolicyArchive)">
+        <Error Text="Could not locate jar executable." Condition=" '$(JarPath)' == '' " />
+        <Error Text="jar could not be located at '$(JarPath)'." Condition="!Exists('$(JarPath)')" />
+        <Exec Command="chmod +x $(JarPath) &gt;/dev/null 2&gt;&amp;1" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" StandardErrorImportance="low" ContinueOnError="true" Condition="$([MSBuild]::IsOSUnixLike())" />
+
+        <WriteLinesToFile Lines="Crypto-Strength: unlimited" File="$(USExportPolicyArchive).manifest" Overwrite="true" />
+        <Exec Command="$(JarExec) cfm $(USExportPolicyArchive).tmp $(USExportPolicyArchive).manifest @(USExportPolicyFiles->'-C %(RootDir)%(Directory) %(Filename)%(Extension)', ' ')" />
+        <Move SourceFiles="$(USExportPolicyArchive).tmp" DestinationFiles="$(USExportPolicyArchive)" />
+        <Touch Files="$(USExportPolicyArchive)" ForceTouch="true" AlwaysCreate="true" />
+        
+        <ItemGroup>
+            <IkvmImageItem Include="$(USExportPolicyArchive)" ImagePath="lib\security\policy\unlimited\US_export_policy.jar" TargetFramework="any" RuntimeIdentifier="any" />
+            <IkvmImageItem Include="$(USExportPolicyArchive)" ImagePath="lib\security\policy\limited\US_export_policy.jar" TargetFramework="any" RuntimeIdentifier="any" />
+            <FileWrites Include="$(USExportPolicyArchive)" />
+            <FileWrites Include="$(USExportPolicyArchive).tmp" />
+            <FileWrites Include="$(USExportPolicyArchive).manifest" />
+        </ItemGroup>
+    </Target>
+
+    <PropertyGroup>
+        <GenerateDependsOn>
+            GenerateUSExportPolicy;
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <LimitedLocalPolicyArchive>$(IntermediateOutputPath)limited_local_policy.jar</LimitedLocalPolicyArchive>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <LimitedLocalPolicyFiles Include="$(OpenJdkDir)jdk\make\data\cryptopolicy\limited\default_local.policy" />
+        <LimitedLocalPolicyFiles Include="$(OpenJdkDir)jdk\make\data\cryptopolicy\limited\exempt_local.policy" />
+    </ItemGroup>
+
+    <Target Name="GenerateLimitedLocalPolicy" DependsOnTargets="ResolveJar" Inputs="$(MSBuildThisFileFullPath);@(LimitedLocalPolicyFiles)" Outputs="$(LimitedLocalPolicyArchive)">
+        <Error Text="Could not locate jar executable." Condition=" '$(JarPath)' == '' " />
+        <Error Text="jar could not be located at '$(JarPath)'." Condition="!Exists('$(JarPath)')" />
+        <Exec Command="chmod +x $(JarPath) &gt;/dev/null 2&gt;&amp;1" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" StandardErrorImportance="low" ContinueOnError="true" Condition="$([MSBuild]::IsOSUnixLike())" />
+
+        <WriteLinesToFile Lines="Crypto-Strength: limited" File="$(LimitedLocalPolicyArchive).manifest" Overwrite="true" />
+        <Exec Command="$(JarExec) cfm $(LimitedLocalPolicyArchive).tmp $(LimitedLocalPolicyArchive).manifest @(LimitedLocalPolicyFiles->'-C %(RootDir)%(Directory) %(Filename)%(Extension)', ' ')" />
+        <Move SourceFiles="$(LimitedLocalPolicyArchive).tmp" DestinationFiles="$(LimitedLocalPolicyArchive)" />
+        <Touch Files="$(LimitedLocalPolicyArchive)" ForceTouch="true" AlwaysCreate="true" />
+
+        <ItemGroup>
+            <IkvmImageItem Include="$(LimitedLocalPolicyArchive)" ImagePath="lib\security\policy\limited\local_policy.jar" TargetFramework="any" RuntimeIdentifier="any" />
+            <FileWrites Include="$(LimitedLocalPolicyArchive)" />
+            <FileWrites Include="$(LimitedLocalPolicyArchive).tmp" />
+            <FileWrites Include="$(LimitedLocalPolicyArchive).manifest" />
+        </ItemGroup>
+    </Target>
+
+    <PropertyGroup>
+        <GenerateDependsOn>
+            GenerateLimitedLocalPolicy;
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <UnlimitedLocalPolicyArchive>$(IntermediateOutputPath)unlimited_local_policy.jar</UnlimitedLocalPolicyArchive>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <UnlimitedLocalPolicyFiles Include="$(OpenJdkDir)jdk\make\data\cryptopolicy\unlimited\default_local.policy" />
+    </ItemGroup>
+
+    <Target Name="GenerateUnlimitedLocalPolicy" DependsOnTargets="ResolveJar" Inputs="$(MSBuildThisFileFullPath);@(UnlimitedLocalPolicyFiles)" Outputs="$(UnlimitedLocalPolicyArchive)">
+        <Error Text="Could not locate jar executable." Condition=" '$(JarPath)' == '' " />
+        <Error Text="jar could not be located at '$(JarPath)'." Condition="!Exists('$(JarPath)')" />
+        <Exec Command="chmod +x $(JarPath) &gt;/dev/null 2&gt;&amp;1" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" StandardErrorImportance="low" ContinueOnError="true" Condition="$([MSBuild]::IsOSUnixLike())" />
+
+        <WriteLinesToFile Lines="Crypto-Strength: unlimited" File="$(UnlimitedLocalPolicyArchive).manifest" Overwrite="true" />
+        <Exec Command="$(JarExec) cfm $(UnlimitedLocalPolicyArchive).tmp $(UnlimitedLocalPolicyArchive).manifest @(UnlimitedLocalPolicyFiles->'-C %(RootDir)%(Directory) %(Filename)%(Extension)', ' ')" />
+        <Move SourceFiles="$(UnlimitedLocalPolicyArchive).tmp" DestinationFiles="$(UnlimitedLocalPolicyArchive)" />
+        <Touch Files="$(UnlimitedLocalPolicyArchive)" ForceTouch="true" AlwaysCreate="true" />
+
+        <ItemGroup>
+            <IkvmImageItem Include="$(UnlimitedLocalPolicyArchive)" ImagePath="lib\security\policy\unlimited\local_policy.jar" TargetFramework="any" RuntimeIdentifier="any" />
+            <FileWrites Include="$(UnlimitedLocalPolicyArchive)" />
+            <FileWrites Include="$(UnlimitedLocalPolicyArchive).tmp" />
+            <FileWrites Include="$(UnlimitedLocalPolicyArchive).manifest" />
+        </ItemGroup>
+    </Target>
+
+    <PropertyGroup>
+        <GenerateDependsOn>
+            GenerateUnlimitedLocalPolicy;
             $(GenerateDependsOn);
         </GenerateDependsOn>
     </PropertyGroup>

--- a/src/IKVM.Image/IKVM.Image.project.targets
+++ b/src/IKVM.Image/IKVM.Image.project.targets
@@ -39,6 +39,18 @@
         <Message Text="Using javac executable found in JAVA_HOME at '$(JavaCompilerPath)'." Importance="high" Condition=" '$(JavaCompilerPath)' != '' " />
     </Target>
 
+    <!-- IKVM.Java uses the jar executable from JAVA_HOME -->
+    <Target Name="ResolveJar" Condition=" '$(JAVA_HOME)' != '' And '$(JarPath)' == '' ">
+        <PropertyGroup>
+            <JarPath Condition=" '$([MSBuild]::IsOSUnixLike())' == 'true' And Exists('$(JAVA_HOME)\bin\jar') ">$([System.IO.Path]::GetFullPath('$(JAVA_HOME)\bin\jar'))</JarPath>
+            <JarPath Condition=" '$([MSBuild]::IsOSUnixLike())' != 'true' And Exists('$(JAVA_HOME)\bin\jar.exe') ">$([System.IO.Path]::GetFullPath('$(JAVA_HOME)\bin\jar.exe'))</JarPath>
+            <JarArgs></JarArgs>
+            <JarExec Condition=" '$(JarPath)' != '' ">"$(JarPath)" $(JarArgs)</JarExec>
+        </PropertyGroup>
+        <Message Text="Using jar executable found in JAVA_HOME at '$(JarPath)'." Importance="high" Condition=" '$(JarPath)' != '' " />
+        <Error Text="Could not locate jar executable in JAVA_HOME. Ensure JAVA_HOME is set to an appropriate bootstrap JDK." Condition=" '$(JarPath)' == '' " />
+    </Target>
+
     <Target Name="GetIkvmImageItemsToPack" DependsOnTargets="CollectIkvmImageItemsOutputItems" BeforeTargets="_GetPackageFiles" Condition=" '$(TargetFramework)' == '' ">
         <ItemGroup>
             <_PackageFiles Include="@(IkvmImageItem)">

--- a/src/IKVM.Java.runtime.linux/IKVM.Java.runtime.linux.csproj
+++ b/src/IKVM.Java.runtime.linux/IKVM.Java.runtime.linux.csproj
@@ -2,7 +2,7 @@
     <Import Project="$(MSBuildThisFileDirectory)..\IKVM.NET.Sdk\Sdk\Sdk.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <PackageId>IKVM.Java.runtime.linux</PackageId>
         <IkvmJavaRuntimeIdentifier>linux</IkvmJavaRuntimeIdentifier>
     </PropertyGroup>

--- a/src/IKVM.Java.runtime.osx/IKVM.Java.runtime.osx.csproj
+++ b/src/IKVM.Java.runtime.osx/IKVM.Java.runtime.osx.csproj
@@ -2,7 +2,7 @@
     <Import Project="$(MSBuildThisFileDirectory)..\IKVM.NET.Sdk\Sdk\Sdk.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <PackageId>IKVM.Java.runtime.osx</PackageId>
         <IkvmJavaRuntimeIdentifier>osx</IkvmJavaRuntimeIdentifier>
     </PropertyGroup>

--- a/src/IKVM.Java/IKVM.Java.csproj
+++ b/src/IKVM.Java/IKVM.Java.csproj
@@ -5,7 +5,8 @@
         <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
         <PackageId>IKVM.Java</PackageId>
         <IkvmJavaRuntimeIdentifier>ref</IkvmJavaRuntimeIdentifier>
-        <DebugSymbols>none</DebugSymbols>
+        <DebugSymbols>false</DebugSymbols>
+        <DebugType>none</DebugType>
         <TargetsTriggeredByCompilation>$(TargetsTriggeredByCompilation);ConvertRefAssembly</TargetsTriggeredByCompilation>
     </PropertyGroup>
 

--- a/src/IKVM.Java/IKVM.Java.csproj
+++ b/src/IKVM.Java/IKVM.Java.csproj
@@ -22,7 +22,7 @@
         <ItemGroup>
             <RefasmerCliTool Include="$(PkgJetBrains_Refasmer_CliTool)\tools\net6.0\any\RefasmerCliTool.dll" />
         </ItemGroup>
-        <Exec Command="dotnet exec @(RefasmerCliTool) -r -w &quot;@(IntermediateAssembly)&quot; " />
+        <Exec Command="dotnet exec @(RefasmerCliTool) --refasm --overwrite --noattr --all &quot;@(IntermediateAssembly)&quot; " />
     </Target>
 
     <Import Project="..\IKVM.Java\IKVM.Java.runtime.props" />

--- a/src/IKVM.Java/IKVM.Java.csproj
+++ b/src/IKVM.Java/IKVM.Java.csproj
@@ -5,7 +5,21 @@
         <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
         <PackageId>IKVM.Java</PackageId>
         <IkvmJavaRuntimeIdentifier>ref</IkvmJavaRuntimeIdentifier>
+        <DebugSymbols>none</DebugSymbols>
+        <TargetsTriggeredByCompilation>$(TargetsTriggeredByCompilation);ConvertRefAssembly</TargetsTriggeredByCompilation>
     </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="JetBrains.Refasmer.CliTool" Version="1.0.33">
+            <PrivateAssets>all</PrivateAssets>
+            <ExcludeAssets>all</ExcludeAssets>
+            <GeneratePathProperty>true</GeneratePathProperty>
+        </PackageReference>
+    </ItemGroup>
+
+    <Target Name="ConvertRefAssembly">
+        <Exec Command="dotnet exec $(PkgJetBrains_Refasmer_CliTool)\tools\net6.0\any\RefasmerCliTool.dll -r -w &quot;@(IntermediateAssembly)&quot; " />
+    </Target>
 
     <Import Project="..\IKVM.Java\IKVM.Java.runtime.props" />
     <Import Project="$(MSBuildThisFileDirectory)..\IKVM.NET.Sdk\Sdk\Sdk.targets" />

--- a/src/IKVM.Java/IKVM.Java.csproj
+++ b/src/IKVM.Java/IKVM.Java.csproj
@@ -19,7 +19,10 @@
     </ItemGroup>
 
     <Target Name="ConvertRefAssembly">
-        <Exec Command="dotnet exec $(PkgJetBrains_Refasmer_CliTool)\tools\net6.0\any\RefasmerCliTool.dll -r -w &quot;@(IntermediateAssembly)&quot; " />
+        <ItemGroup>
+            <RefasmerCliTool Include="$(PkgJetBrains_Refasmer_CliTool)\tools\net6.0\any\RefasmerCliTool.dll" />
+        </ItemGroup>
+        <Exec Command="dotnet exec @(RefasmerCliTool) -r -w &quot;@(IntermediateAssembly)&quot; " />
     </Target>
 
     <Import Project="..\IKVM.Java\IKVM.Java.runtime.props" />

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.props
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.props
@@ -12,7 +12,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <OpenJdkSource Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\gensrc\sun\util\locale\provider\LocaleDataMetaInfo.java" PackagePath="sun\util\locale\provider" />
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\com\sun\awt\**\*.java" PackagePath="com\sun\awt" />
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\com\sun\beans\**\*.java" PackagePath="com\sun\beans" />
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\com\sun\crypto\**\*.java" PackagePath="com\sun\crypto" />

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.props
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.props
@@ -126,8 +126,11 @@
         <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\security\smartcardio\**\*.java" />
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\sun\swing\**\*.java" PackagePath="sun\swing" />
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\sun\text\**\*.java" PackagePath="sun\text" />
+        <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\text\resources\BreakIteratorInfo.java" />
         <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\text\resources\BreakIteratorRules.java" />
-        <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\text\resources\BreakIteratorRules_th.java" />
+        <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\text\resources\th\BreakIteratorInfo_th.java" />
+        <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\text\resources\th\BreakIteratorRules_th.java" />
+
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\sun\tools\**\*.java" PackagePath="sun\tools" />
         <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\tools\attach\**\*.java" />
         <OpenJdkSource Remove="$(OpenJdkDir)\jdk\src\share\classes\sun\tools\jcmd\**\*.java" />

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.props
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.props
@@ -12,7 +12,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <OpenJdkSource Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\gensrc\sun\util\CoreResourceBundleControl.java" PackagePath="sun\util" />
         <OpenJdkSource Include="$(OpenJdkDir)\build\linux-x86_64-normal-server-release\jdk\gensrc\sun\util\locale\provider\LocaleDataMetaInfo.java" PackagePath="sun\util\locale\provider" />
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\com\sun\awt\**\*.java" PackagePath="com\sun\awt" />
         <OpenJdkSource Include="$(OpenJdkDir)\jdk\src\share\classes\com\sun\beans\**\*.java" PackagePath="com\sun\beans" />

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
@@ -181,11 +181,11 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateCharacterData;
             GenerateCharacterDataStatic;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <Target Name="GenerateCharsetDecoder" DependsOnTargets="OpenJdkBuildTools;ResolveJava" Inputs="$(MSBuildThisFileFullPath);$(OpenJdkBuildToolsStampFile);$(OpenJdkDir)jdk\src\share\classes\java\nio\charset\Charset-X-Coder.java.template" Outputs="$(IntermediateOutputPath)genchardec\java\nio\charset\CharsetDecoder.java">
@@ -288,11 +288,11 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateCharsetDecoder;
             GenerateCharsetEncoder;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -607,11 +607,11 @@ public class WriteStandardCharsets : Task
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateCharsetMappings;
             GenerateStandardCharsets;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <Target Name="GenerateHtml32DTD" DependsOnTargets="OpenJdkBuildTools;ResolveJava" Inputs="$(MSBuildThisFileFullPath);$(OpenJdkBuildToolsStampFile);@(BuildScripts)" Outputs="$(IntermediateOutputPath)genhtml32dtd\javax\swing\text\html\parser\html32.bdtd">
@@ -638,10 +638,10 @@ public class WriteStandardCharsets : Task
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateHtml32DTD;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <!--
@@ -665,10 +665,10 @@ public class WriteStandardCharsets : Task
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateExceptions;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <!--
@@ -1065,11 +1065,11 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateBuffersSetup;
             GenerateBuffers;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1100,10 +1100,10 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateCalendarData;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -1168,10 +1168,10 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateIcons;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1199,10 +1199,10 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateNimbus;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1247,10 +1247,10 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateX11Wrappers;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1276,10 +1276,10 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateUniName;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1302,10 +1302,10 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateLocaleEquivalentMaps;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1365,11 +1365,11 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateBreakIteratorClasses;
             GenerateBreakIteratorData;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1381,7 +1381,7 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
         <CoreResourceBundleControlNonExistLocales Include="en;en_US;de_DE;es_ES;fr_FR;it_IT;ja_JP;ko_KR;sv_SE;zh" />
     </ItemGroup>
 
-    <UsingTask TaskName="LocaleListTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <UsingTask TaskName="GenerateCoreResourceBundleControl" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
         <ParameterGroup>
             <LocaleList ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
             <SourceFile ParameterType="System.String" Required="true" />
@@ -1431,7 +1431,7 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </UsingTask>
 
     <Target Name="GenerateCoreResourceBundleControl" Inputs="$(MSBuildThisFileFullPath);$(CoreResourceBundleControlSrc)" Outputs="$(CoreResourceBundleControlDst)">
-        <LocaleListTask
+        <GenerateCoreResourceBundleControl
             SourceFile="$(CoreResourceBundleControlSrc)"
             OutputFile="$(CoreResourceBundleControlDst)"
             LocaleList="@(CoreResourceBundleControlNonExistLocales)" />
@@ -1443,10 +1443,125 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateCoreResourceBundleControl;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <LocaleDataMetaInfoSrc>$(OpenJdkDir)jdk\src\share\classes\sun\util\locale\provider\LocaleDataMetaInfo-XLocales.java.template</LocaleDataMetaInfoSrc>
+        <LocaleDataMetaInfoDst>$(IntermediateOutputPath)LocaleDataMetaInfo.java</LocaleDataMetaInfoDst>
+    </PropertyGroup>
+
+    <UsingTask TaskName="GenerateLocaleDataMetaInfo" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+        <ParameterGroup>
+            <LocaleResourceList ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+            <SourceFile ParameterType="System.String" Required="true" />
+            <OutputFile ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System" />
+            <Using Namespace="System.Linq" />
+            <Using Namespace="System.Collections.Generic" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                var all_en = new HashSet<string>();
+                var all_non_en = new HashSet<string>() { "ja-JP-JP", "th-TH-TH" };
+                var resources = new HashSet<string>();
+                var locale_en = new Dictionary<string, HashSet<string>>();
+                var locale_non_en = new Dictionary<string, HashSet<string>>();
+                
+                // deconstruct Filename_LOCAL.ext into a list of en and non-en locales
+                foreach (var i in LocaleResourceList)
+                {
+                    var f = i.GetMetadata("Filename");
+                    var a = f.Split(new[] { '_' }, 2);
+                    var n = a[0];
+                    resources.Add(n);
+                    
+                    var l = a[1].Replace("_", "-");
+                    if (l.StartsWith("en"))
+                    {
+                        if (locale_en.TryGetValue(n, out var en) == false)
+                            locale_en[n] = en = new HashSet<string>();
+                        
+                        en.Add(l);
+                        all_en.Add(l);
+                    }
+                    else
+                    {
+                        if (locale_non_en.TryGetValue(n, out var non_en) == false)
+                            locale_non_en[n] = non_en = new HashSet<string>();
+                        
+                        non_en.Add(l);
+                        all_non_en.Add(l);
+                    }
+                }
+                
+                using var src = File.OpenText(SourceFile);
+                using var dst = new StreamWriter(File.Open(OutputFile, FileMode.Create));
+                
+                string line;
+                while ((line = src.ReadLine()) != null)
+                {
+                    if (line.StartsWith("#"))
+                        continue;
+                
+                    foreach (var resource in resources)
+                    {
+                        var en = locale_en.TryGetValue(resource, out var _en) ? _en.OrderBy(i => i) : Enumerable.Empty<string>();
+                        line = line.Replace($"#{resource}_ENLocales#", string.Join(" ", en));
+                        
+                        var non_en = locale_non_en.TryGetValue(resource, out var _non_en) ? _non_en.OrderBy(i => i) : Enumerable.Empty<string>();
+                        line = line.Replace($"#{resource}_NonENLocales#", string.Join(" ", non_en));
+                    }
+                   
+                    line = line.Replace("#AvailableLocales_ENLocales#", string.Join(" ", all_en.OrderBy(i => i)));
+                    line = line.Replace("#AvailableLocales_NonENLocales#", string.Join(" ", all_non_en.OrderBy(i => i)));
+                    dst.WriteLine(line);
+                }   
+                ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+
+    <Target Name="GenerateLocaleDataMetaInfo" Inputs="$(MSBuildThisFileFullPath);$(LocaleDataMetaInfoSrc)" Outputs="$(LocaleDataMetaInfoDst)">
+        <ItemGroup>
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\FormatData_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\FormatData_*.properties" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\CollationData_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\CollationData_*.properties" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\TimeZoneNames_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\TimeZoneNames_*.properties" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\LocaleNames_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\LocaleNames_*.properties" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\CurrencyNames_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\CurrencyNames_*.properties" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\CalendarData_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\CalendarData_*.properties" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\BreakIteratorInfo_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\BreakIteratorInfo_*.properties" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\BreakIteratorRules_*.java" />
+            <LocaleResourceList Include="$(OpenJdkDir)jdk\src\share\classes\**\BreakIteratorRules_*.properties" />
+        </ItemGroup>
+
+        <GenerateLocaleDataMetaInfo
+            SourceFile="$(LocaleDataMetaInfoSrc)"
+            OutputFile="$(LocaleDataMetaInfoDst)"
+            LocaleResourceList="@(LocaleResourceList)" />
+
+        <ItemGroup>
+            <FileWrites Include="$(LocaleDataMetaInfoDst)" />
+            <Compile Include="$(LocaleDataMetaInfoDst)" />
+        </ItemGroup>
+    </Target>
+
+    <PropertyGroup>
+        <GenerateDependsOn>
+            GenerateLocaleDataMetaInfo;
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
 </Project>

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
@@ -1213,7 +1213,7 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
         <XLibSizes64>$(OpenJdkDir)jdk\src\solaris\classes\sun\awt\X11\generator\sizes.64</XLibSizes64>
     </PropertyGroup>
 
-    <Target Name="GenerateX11Wrappers" DependsOnTargets="OpenJdkBuildTools;ResolveJava" Inputs="$(MSBuildThisFileFullPath);$(OpenJdkBuildToolsStampFile);$(XLibSizes32);$(XLibSizes64);$(XLibTypes)" Outputs="$(X11WrapperTempPath)sizes.32;$(X11WrapperTempPath)sizes.64;$(IntermediateOutputPath)genx11.stamp" Condition=" '$(IkvmJavaRuntimeIdentifier)' == 'linux' ">
+    <Target Name="GenerateX11Wrappers" DependsOnTargets="OpenJdkBuildTools;ResolveJava" Inputs="$(MSBuildThisFileFullPath);$(OpenJdkBuildToolsStampFile);$(XLibSizes32);$(XLibSizes64);$(XLibTypes)" Outputs="$(IntermediateOutputPath)genx11.stamp" Condition=" '$(IkvmJavaRuntimeIdentifier)' == 'linux' ">
         <Error Text="Could not locate java executable." Condition=" '$(JavaPath)' == '' " />
         <Error Text="java could not be located at '$(JavaPath)'." Condition="!Exists('$(JavaPath)')" />
         <Exec Command="chmod +x $(JavaPath) >/dev/null 2>&amp;1" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" StandardErrorImportance="low" ContinueOnError="true" Condition="$([MSBuild]::IsOSUnixLike())" />

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
@@ -1342,6 +1342,7 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
 
         <ItemGroup>
             <FileWrites Include="@(BreakIteratorOutputs)" />
+            <Compile Include="@(BreakIteratorOutputs)" />
         </ItemGroup>
     </Target>
 

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
@@ -1372,4 +1372,81 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
         </GenerateSourceDependsOn>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <CoreResourceBundleControlSrc>$(OpenJdkDir)jdk\src\share\classes\sun\util\CoreResourceBundleControl-XLocales.java.template</CoreResourceBundleControlSrc>
+        <CoreResourceBundleControlDst>$(IntermediateOutputPath)CoreResourceBundleControl.java</CoreResourceBundleControlDst>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <CoreResourceBundleControlNonExistLocales Include="en;en_US;de_DE;es_ES;fr_FR;it_IT;ja_JP;ko_KR;sv_SE;zh" />
+    </ItemGroup>
+
+    <UsingTask TaskName="LocaleListTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+        <ParameterGroup>
+            <LocaleList ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+            <SourceFile ParameterType="System.String" Required="true" />
+            <OutputFile ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System" />
+            <Using Namespace="System.Collections.Generic" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                var l = new List<string>();
+                
+                var o = new Dictionary<string, string>();
+                o["en"] = "ENGLISH";
+                o["fr"] = "FRENCH";
+                o["de"] = "GERMAN";
+                o["it"] = "ITALIAN";
+                o["ja"] = "JAPANESE";
+                o["ko"] = "KOREAN";
+                o["zh"] = "CHINESE";
+                o["zh_CN"] = "SIMPLIFIED_CHINESE";
+                o["zh_TW"] = "TRADITIONAL_CHINESE";
+                o["fr_FR"] = "FRANCE";
+                o["de_DE"] = "GERMANY";
+                o["it_IT"] = "ITALY";
+                o["ja_JP"] = "JAPAN";
+                o["ko_KR"] = "KOREA";
+                o["en_GB"] = "UK";
+                o["en_US"] = "US";
+                o["en_CA"] = "CANADA";
+                o["fr_CA"] = "CANADA_FRENCH";
+                
+                foreach (var locale in LocaleList)
+                    l.Add(o.ContainsKey(locale.ItemSpec) ? "Locale." + o[locale.ItemSpec] : "new Locale(\"" + string.Join("\", \"", locale.ItemSpec.Split('_')) + "\")");
+                
+                using var src = File.OpenText(SourceFile);
+                using var dst = new StreamWriter(File.Open(OutputFile, FileMode.Create));
+                
+                string line;
+                while ((line = src.ReadLine()) != null)
+                    if (line.StartsWith("#warn") == false)
+                        dst.WriteLine(line.Replace("#LOCALE_LIST#", string.Join(", ", l)));
+                    
+                ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+
+    <Target Name="GenerateCoreResourceBundleControl" Inputs="$(MSBuildThisFileFullPath);$(CoreResourceBundleControlSrc)" Outputs="$(CoreResourceBundleControlDst)">
+        <LocaleListTask
+            SourceFile="$(CoreResourceBundleControlSrc)"
+            OutputFile="$(CoreResourceBundleControlDst)"
+            LocaleList="@(CoreResourceBundleControlNonExistLocales)" />
+        
+        <ItemGroup>
+            <FileWrites Include="$(CoreResourceBundleControlDst)" />
+            <Compile Include="$(CoreResourceBundleControlDst)" />
+        </ItemGroup>
+    </Target>
+
+    <PropertyGroup>
+        <GenerateSourceDependsOn>
+            GenerateCoreResourceBundleControl;
+            $(GenerateSourceDependsOn);
+        </GenerateSourceDependsOn>
+    </PropertyGroup>
+
 </Project>

--- a/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
+++ b/src/IKVM.Java/IKVM.Java.runtime.jdk.targets
@@ -1342,7 +1342,7 @@ File.WriteAllLines(Path, File.ReadAllLines(Path).TakeWhile(i => i.Contains("#BIN
 
         <ItemGroup>
             <FileWrites Include="@(BreakIteratorOutputs)" />
-            <Compile Include="@(BreakIteratorOutputs)" />
+            <Convert Include="@(BreakIteratorOutputs)" />
         </ItemGroup>
     </Target>
 

--- a/src/IKVM.Java/IKVM.Java.runtime.langtools.targets
+++ b/src/IKVM.Java/IKVM.Java.runtime.langtools.targets
@@ -42,10 +42,10 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateLangtoolsVersionProperties;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
 </Project>

--- a/src/IKVM.Java/IKVM.Java.runtime.targets
+++ b/src/IKVM.Java/IKVM.Java.runtime.targets
@@ -39,10 +39,10 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             OpenJdkBuildTools;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <UsingTask TaskName="GetCompilePropertiesArgs" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
@@ -99,10 +99,10 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             GenerateResourceBundles;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <UsingTask TaskName="AddPropertiesToClean" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
@@ -157,10 +157,10 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             CleanProperties;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <UsingTask TaskName="DuplicateProperties" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
@@ -210,11 +210,11 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             FilterDuplicateProperties;
             DuplicateProperties;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <UsingTask TaskName="DistinctServiceFiles" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
@@ -295,36 +295,29 @@
     </Target>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
+        <GenerateDependsOn>
             UpdateServiceFiles;
             GenerateServiceFiles;
             CollectServiceFiles;
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
     <PropertyGroup>
-        <GenerateSourceDependsOn>
-            $(GenerateSourceDependsOn);
-        </GenerateSourceDependsOn>
+        <GenerateDependsOn>
+            $(GenerateDependsOn);
+        </GenerateDependsOn>
     </PropertyGroup>
 
-    <Target Name="GenerateSource" DependsOnTargets="$(GenerateSourceDependsOn)">
+    <Target Name="Generate" DependsOnTargets="$(GenerateDependsOn)">
 
     </Target>
 
     <PropertyGroup>
         <CompileJavaDependsOn>
-            GenerateSource;
+            Generate;
             $(CompileJavaDependsOn);
         </CompileJavaDependsOn>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <CoreCleanDependsOn>
-            $(CoreCleanDependsOn);
-            CleanGenerateSource;
-        </CoreCleanDependsOn>
     </PropertyGroup>
 
     <UsingTask TaskName="WriteTextToFile" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">

--- a/src/IKVM.MSBuild/buildTransitive/IKVM.MSBuild.Tasks.targets
+++ b/src/IKVM.MSBuild/buildTransitive/IKVM.MSBuild.Tasks.targets
@@ -7,7 +7,7 @@
         <MSBuildRuntimeVersion Condition=" '$(MSBuildRuntimeVersion)' == '' ">$([System.Runtime.InteropServices.RuntimeInformation]:: FrameworkDescription.ToString())</MSBuildRuntimeVersion>
         <IkvmMSBuildTaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">net6.0</IkvmMSBuildTaskFolder>
         <IkvmMSBuildTaskFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' ">net472</IkvmMSBuildTaskFolder>
-        <IkvmMSBuildTaskFactory Condition=" '$(MSBuildRuntimeType)' == 'Core' ">TaskHostFactory</IkvmMSBuildTaskFactory>
+        <IkvmMSBuildTaskFactory Condition=" '$(MSBuildRuntimeType)' == 'Core' "></IkvmMSBuildTaskFactory>
         <IkvmMSBuildTaskFactory Condition=" '$(MSBuildRuntimeType)' != 'Core' ">TaskHostFactory</IkvmMSBuildTaskFactory>
         <IkvmMSBuildTaskAssembly>$(MSBuildThisFileDirectory)..\tasks\$(IkvmMSBuildTaskFolder)\IKVM.MSBuild.Tasks.dll</IkvmMSBuildTaskAssembly>
         <IkvmCompilerToolPath>@(IkvmCompilerToolPath->WithMetadataValue('TargetFramework', '$(IkvmToolFramework)')->WithMetadataValue('RuntimeIdentifier', '$(IkvmToolRuntime)'))</IkvmCompilerToolPath>

--- a/src/IKVM.NET.Sdk.Tests/ProjectTests.cs
+++ b/src/IKVM.NET.Sdk.Tests/ProjectTests.cs
@@ -108,6 +108,7 @@ namespace IKVM.NET.Sdk.Tests
             var analyzer = manager.GetProject(Path.Combine(TestRoot, "Exe", "ProjectExe.msbuildproj"));
             analyzer.AddBuildLogger(new TargetLogger(context));
             analyzer.AddBinaryLogger(Path.Combine(WorkRoot, "msbuild.binlog"));
+            analyzer.SetEnvironmentVariable("NUGET_PACKAGES", "");
             analyzer.SetGlobalProperty("ImportDirectoryBuildProps", "false");
             analyzer.SetGlobalProperty("ImportDirectoryBuildTargets", "false");
             analyzer.SetGlobalProperty("IkvmCacheDir", IkvmCachePath + Path.DirectorySeparatorChar);
@@ -231,6 +232,7 @@ namespace IKVM.NET.Sdk.Tests
             var analyzer = manager.GetProject(Path.Combine(@"Project", "Exe", "ProjectExe.msbuildproj"));
             analyzer.AddBuildLogger(new TargetLogger(TestContext));
             analyzer.AddBinaryLogger(Path.Combine(WorkRoot, $"{env}-{tfm}-{rid}-msbuild.binlog"));
+            analyzer.SetEnvironmentVariable("NUGET_PACKAGES", "");
             analyzer.SetGlobalProperty("ImportDirectoryBuildProps", "false");
             analyzer.SetGlobalProperty("ImportDirectoryBuildTargets", "false");
             analyzer.SetGlobalProperty("IkvmCacheDir", IkvmCachePath + Path.DirectorySeparatorChar);

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.NoTasks.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.NoTasks.targets
@@ -152,6 +152,7 @@ Value = b.ToString();
         <Exec Command="$(IkvmExporterExec) @(_IkvmExporterArgs, ' ')" Condition="!Exists('%(ReferenceExport.CachePath)')" IgnoreStandardErrorWarningFormat="true" />
         <Copy SourceFiles="%(ReferenceExport.StagePath)" DestinationFiles="%(ReferenceExport.CachePath).$(_ExportReferenceTempSuffix)" OverwriteReadOnlyFiles="true" UseHardlinksIfPossible="true" Retries="$(CopyRetryCount)" RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)" Condition="!Exists('%(ReferenceExport.CachePath)')" />
         <Move SourceFiles="%(ReferenceExport.CachePath).$(_ExportReferenceTempSuffix)" DestinationFiles="%(ReferenceExport.CachePath)" OverwriteReadOnlyFiles="true" Condition="!Exists('%(ReferenceExport.CachePath)')" />
+        <Touch Files="%(ReferenceExport.CachePath)" ForceTouch="true" />
 
         <ItemGroup>
             <FileWrites Include="%(ReferenceExport.StagePath)" />
@@ -336,6 +337,8 @@ Value = b.ToString();
             <FileWrites Include="$(_AssemblyTempPath)$(TargetName)$(TargetExt)" />
             <FileWrites Include="$(_AssemblyTempPath)$(TargetName).pdb" />
         </ItemGroup>
+
+        <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition=" '$(TargetsTriggeredByCompilation)' != '' " />
     </Target>
 
 </Project>

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.Tasks.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.Tasks.targets
@@ -149,6 +149,8 @@
             <FileWrites Include="$(_AssemblyTempPath)$(TargetName)$(TargetExt)" />
             <FileWrites Include="$(_AssemblyTempPath)$(TargetName).pdb" />
         </ItemGroup>
+
+        <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition=" '$(TargetsTriggeredByCompilation)' != '' " />
     </Target>
 
 </Project>

--- a/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
+++ b/src/IKVM.NET.Sdk/targets/IKVM.Java.Core.targets
@@ -204,7 +204,7 @@ Files = files.ToArray();
     </PropertyGroup>
 
     <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">
-        <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition=" '$(TargetsTriggeredByCompilation)' != '' " />
+        
     </Target>
 
     <Target Name="CleanCoreCompile">


### PR DESCRIPTION
Generating everything for the jdk/ project. Corba and Nashorn remain.
Removed net472 builds for IKVM.Java.runtime.linux and osx.
Run a tool to convert IKVM.Java ref assembly into an actual ref assembly. Needs some work since ikvmc is sort of unhappy with a pure ref assembly. But this reduces the size by over half.
Remove SourceLink for now. This is causing unnecessary rebuilds.