### PR TITLE
`Assembly.Location` might return an empty string.

### DIFF
--- a/src/IKVM.Runtime/LibIkvm.cs
+++ b/src/IKVM.Runtime/LibIkvm.cs
@@ -218,7 +218,7 @@ namespace IKVM.Runtime
                 return h1;
 
             // start looking at assembly path, or path given by environmental variable
-            var asml = typeof(NativeLibrary).Assembly.Location is string s ? Path.GetDirectoryName(s) : null;
+            var asml = typeof(NativeLibrary).Assembly.Location is string s && !string.IsNullOrEmpty(s) ? Path.GetDirectoryName(s) : null;
             var root = Environment.GetEnvironmentVariable("IKVM_LIBRARY_PATH") ?? asml ?? AppContext.BaseDirectory;
 
             // assembly possible loaded in memory: we have no available search path

--- a/src/IKVM.Runtime/NativeLibrary.cs
+++ b/src/IKVM.Runtime/NativeLibrary.cs
@@ -73,7 +73,7 @@ namespace IKVM.Runtime
                 return h1;
 
             // start looking at assembly path, or path given by environmental variable
-            var asml = typeof(NativeLibrary).Assembly.Location is string s ? Path.GetDirectoryName(s) : null;
+            var asml = typeof(NativeLibrary).Assembly.Location is string s && !string.IsNullOrEmpty(s) ? Path.GetDirectoryName(s) : null;
             var root = Environment.GetEnvironmentVariable("IKVM_LIBRARY_PATH") ?? asml;
 
             // assembly possible loaded in memory: we have no available search path


### PR DESCRIPTION
`Assembly.Location` might return an empty string.
`Path.GetDirectoryName` on Full Framework will then fail with `The path is not of a legal form.`.