### PR TITLE
Load IKVM.Properties from RuntimeHost Configuration

### DIFF
--- a/src/IKVM.Runtime/JVM.Properties.cs
+++ b/src/IKVM.Runtime/JVM.Properties.cs
@@ -297,6 +297,19 @@ namespace IKVM.Runtime
                 }
 #endif
 
+#if NET
+				if (AppContext.GetData("IKVM.Properties") is { } ikvmPropertiesContext && !string.IsNullOrWhiteSpace(ikvmPropertiesContext))
+				{
+					foreach (var ikvmSystemProperty in ikvmPropertiesContext.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+					{
+						if (AppContext.GetData(ikvmSystemProperty) is { } ikvmPropertyValue)
+						{
+							p[ikvmSystemProperty] = ikvmPropertyValue;
+						}
+					}
+				}
+#endif
+
 				// set the properties that were specfied
 				if (user != null)
 					foreach (var kvp in user)

--- a/src/IKVM.Runtime/JVM.Properties.cs
+++ b/src/IKVM.Runtime/JVM.Properties.cs
@@ -298,16 +298,16 @@ namespace IKVM.Runtime
 #endif
 
 #if NET
-				if (AppContext.GetData("IKVM.Properties") is { } ikvmPropertiesContext && !string.IsNullOrWhiteSpace(ikvmPropertiesContext))
-				{
-					foreach (var ikvmSystemProperty in ikvmPropertiesContext.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-					{
-						if (AppContext.GetData(ikvmSystemProperty) is { } ikvmPropertyValue)
-						{
-							p[ikvmSystemProperty] = ikvmPropertyValue;
-						}
-					}
-				}
+                if (AppContext.GetData("IKVM.Properties") is string ikvmPropertiesContext && !string.IsNullOrWhiteSpace(ikvmPropertiesContext))
+                {
+                    foreach (var ikvmSystemProperty in ikvmPropertiesContext.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    {
+                        if (AppContext.GetData(ikvmSystemProperty) is string ikvmPropertyValue)
+                        {
+                            p[ikvmSystemProperty] = ikvmPropertyValue;
+                        }
+                    }
+                }
 #endif
 
 				// set the properties that were specfied


### PR DESCRIPTION
Allows for specifying system properties like `java.net.preferIPv4Stack` before JVM is initialized when consuming IKVM as a runtime library.

Usage:
```
<ItemGroup>
    <RuntimeHostConfigurationOption Include="IKVM.Properties" Value="java.net.preferIPv4Stack" />
    <RuntimeHostConfigurationOption Include="java.net.preferIPv4Stack" Value="False" />
</ItemGroup>
```

IKVM.Properties is semicolon separated.