### PR TITLE
Quote Assembly Name in IKVM Importer

### DIFF
--- a/src/IKVM.Tools.Runner/Importer/IkvmImporterLauncher.cs
+++ b/src/IKVM.Tools.Runner/Importer/IkvmImporterLauncher.cs
@@ -70,7 +70,7 @@ namespace IKVM.Tools.Runner.Importer
                 w.WriteLine($"-out \"{options.Output}\"");
 
             if (options.Assembly is not null)
-                w.WriteLine($"-assembly {options.Assembly}");
+                w.WriteLine($"-assembly \"{options.Assembly}\"");
 
             if (options.Version is not null)
                 w.WriteLine($"-version {options.Version}");


### PR DESCRIPTION
```
<PropertyGroup>
<AssemblyName>A B.Core</AssemblyName>
</PropertyGoup>
```

Fails with `error 4005: Source file 'B.Core' not found`.