### PR TITLE
Add Arm64 HW cryptography intrinsics

### DIFF
--- a/src/IKVM.Java/map.xml
+++ b/src/IKVM.Java/map.xml
@@ -1699,7 +1699,7 @@
                     <call type="IKVM.Runtime.Util.Com.Sun.Crypto.Provider.CipherBlockChaining" name="DecryptAESCrypt" sig="(Ljava.lang.Object;[BII[BI)I" />
                     <ldarg_3 />
                     <bne_un name="continue" />
-                    <ldarg_3 /> />
+                    <ldarg_3 />
                     <ret />
                     <label name="continue" />
                 </prologue>
@@ -1716,7 +1716,7 @@
                     <call type="IKVM.Runtime.Util.Com.Sun.Crypto.Provider.CipherBlockChaining" name="EncryptAESCrypt" sig="(Ljava.lang.Object;[BII[BI)I" />
                     <ldarg_3 />
                     <bne_un name="continue" />
-                    <ldarg_3 /> />
+                    <ldarg_3 />
                     <ret />
                     <label name="continue" />
                 </prologue>

--- a/src/IKVM.Java/map.xml
+++ b/src/IKVM.Java/map.xml
@@ -1695,10 +1695,11 @@
                     <ldarg_3 />
                     <ldarg_s argNum="4" />
                     <ldarg_s argNum="5" />
-                    <!-- bool CipherBlockChaining.DecryptAESCrypt(object self, byte[] cipher, int cipherOffset, int cipherLen, byte[] plain, int plainOffset, ) -->
-                    <call type="IKVM.Runtime.Util.Com.Sun.Crypto.Provider.CipherBlockChaining" name="DecryptAESCrypt" sig="(Ljava.lang.Object;[BII[BI)Z" />
-                    <brfalse name="continue" />
+                    <!-- int CipherBlockChaining.DecryptAESCrypt(object self, byte[] cipher, int cipherOffset, int cipherLen, byte[] plain, int plainOffset, ) -->
+                    <call type="IKVM.Runtime.Util.Com.Sun.Crypto.Provider.CipherBlockChaining" name="DecryptAESCrypt" sig="(Ljava.lang.Object;[BII[BI)I" />
                     <ldarg_3 />
+                    <bne_un name="continue" />
+                    <ldarg_3 /> />
                     <ret />
                     <label name="continue" />
                 </prologue>
@@ -1711,10 +1712,11 @@
                     <ldarg_3 />
                     <ldarg_s argNum="4" />
                     <ldarg_s argNum="5" />
-                    <!-- bool CipherBlockChaining.EncryptAESCrypt(object self, byte[] plain, int plainOffset, int plainLen, byte[] cipher, int cipherOffset) -->
-                    <call type="IKVM.Runtime.Util.Com.Sun.Crypto.Provider.CipherBlockChaining" name="EncryptAESCrypt" sig="(Ljava.lang.Object;[BII[BI)Z" />
-                    <brfalse name="continue" />
+                    <!-- int CipherBlockChaining.EncryptAESCrypt(object self, byte[] plain, int plainOffset, int plainLen, byte[] cipher, int cipherOffset) -->
+                    <call type="IKVM.Runtime.Util.Com.Sun.Crypto.Provider.CipherBlockChaining" name="EncryptAESCrypt" sig="(Ljava.lang.Object;[BII[BI)I" />
                     <ldarg_3 />
+                    <bne_un name="continue" />
+                    <ldarg_3 /> />
                     <ret />
                     <label name="continue" />
                 </prologue>

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
@@ -74,6 +74,14 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
                 AESCrypt_x86.EncryptBlock(@in.AsSpan(inOffset), @out.AsSpan(outOffset), K);
                 return true;
             }
+
+#if NET6_0_OR_GREATER
+            if (AESCrypt_Arm.IsSupported)
+            {
+                AESCrypt_Arm.EncryptBlock(@in.AsSpan(inOffset), @out.AsSpan(outOffset), K);
+                return true;
+            }
+#endif
 #endif
 
             return false;

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
-
+using System.Runtime.InteropServices;
 using IKVM.Attributes;
 
 namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
@@ -11,7 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// Intercepted implementations for 'com.sun.crypto.provider.CipherBlockChaining'.
     /// </summary>
     [HideFromJava]
-    internal static class AESCrypt
+    internal unsafe static class AESCrypt
     {
 
         /// <summary>

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
@@ -11,7 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// Intercepted implementations for 'com.sun.crypto.provider.CipherBlockChaining'.
     /// </summary>
     [HideFromJava]
-    internal unsafe static class AESCrypt
+    internal static class AESCrypt
     {
 
         /// <summary>

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt.cs
@@ -37,6 +37,14 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
                 AESCrypt_x86.DecryptBlock(@in.AsSpan(inOffset), @out.AsSpan(outOffset), K);
                 return true;
             }
+
+#if NET6_0_OR_GREATER
+            if (AESCrypt_Arm.IsSupported)
+            {
+                AESCrypt_Arm.DecryptBlock(@in.AsSpan(inOffset), @out.AsSpan(outOffset), K);
+                return true;
+            }
+#endif
 #endif
 
             return false;

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
@@ -1,0 +1,121 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+
+namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
+{
+    /// <summary>
+    /// Arm implementation of the AES intrinsic functions.
+    /// </summary>
+    static class AESCrypt_Arm
+    {
+        /// <summary>
+        /// Returns <c>true</c> if the current platform is supported by this implementation.
+        /// </summary>
+        public static bool IsSupported => Aes.IsSupported && AdvSimd.IsSupported;
+
+        /// <summary>
+        /// Implementation of com.sun.crypto.provider.AESCrypt.decryptBlock for the Arm platform.
+        /// Derived from the OpenJDK C code 'stubGenerator_aarch64.cpp:generate_aescrypt_decryptBlock'.
+        /// Keep the structure of the body of this method as close to the orignal C code as possible to facilitate porting changes.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="key"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void DecryptBlock(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key)
+        {
+            var v0 = Vector128Util.LoadUnsafe(ref MemoryMarshal.GetReference(from));
+
+            var v5 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v5 = AdvSimd.ReverseElement8(v5);
+
+            // AdvSimd.Arm64.Load4xVector128 was added with .NET 9
+            // Manually do the steps required.
+            var v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            var v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            var v3 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            var v4 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+            v3 = AdvSimd.ReverseElement8(v3);
+            v4 = AdvSimd.ReverseElement8(v4);
+            v0 = Aes.Decrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v3.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v4.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v3 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v4 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+            v3 = AdvSimd.ReverseElement8(v3);
+            v4 = AdvSimd.ReverseElement8(v4);
+            v0 = Aes.Decrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v3.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v4.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+
+            if (key.Length == 44)
+            {
+                goto doLast;
+            }
+
+            v0 = Aes.Decrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+
+            if (key.Length == 52)
+            {
+                goto doLast;
+            }
+
+            v0 = Aes.Decrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+
+        doLast:;
+
+            v0 = Aes.Decrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Decrypt(v0, v2.AsByte());
+
+            v0 = AdvSimd.Xor(v0, v5.AsByte());
+
+            v0.CopyTo(to);
+        }
+    }
+}
+
+#endif

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
@@ -29,7 +29,9 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void DecryptBlock(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key)
         {
-            var v0 = Vector128Util.LoadUnsafe(ref MemoryMarshal.GetReference(from));
+            var keylen = key.Length;
+
+            var v0 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(from));
 
             var v5 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
             v5 = AdvSimd.ReverseElement8(v5);
@@ -75,7 +77,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             v1 = AdvSimd.ReverseElement8(v1);
             v2 = AdvSimd.ReverseElement8(v2);
 
-            if (key.Length == 44)
+            if (keylen == 44)
             {
                 goto doLast;
             }
@@ -90,7 +92,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             v1 = AdvSimd.ReverseElement8(v1);
             v2 = AdvSimd.ReverseElement8(v2);
 
-            if (key.Length == 52)
+            if (keylen == 52)
             {
                 goto doLast;
             }

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
@@ -29,6 +29,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void DecryptBlock(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key)
         {
+            //ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:2606-2699
             var keylen = key.Length;
 
             var v0 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(from));
@@ -114,6 +115,106 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             v0 = Aes.Decrypt(v0, v2.AsByte());
 
             v0 = AdvSimd.Xor(v0, v5.AsByte());
+
+            v0.CopyTo(to);
+        }
+
+        /// <summary>
+        /// Implementation of com.sun.crypto.provider.AESCrypt.encryptBlock for the Arm platform.
+        /// Derived from the OpenJDK C code 'stubGenerator_aarch64.cpp:generate_aescrypt_encryptBlock'.
+        /// Keep the structure of the body of this method as close to the orignal C code as possible to facilitate porting changes.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="key"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void EncryptBlock(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key)
+        {
+            //ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:2505-2597
+            var keylen = key.Length;
+
+            var v0 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(from));
+
+            // AdvSimd.Arm64.Load4xVector128 was added with .NET 9
+            // Manually do the steps required.
+            var v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            var v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            var v3 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            var v4 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+            v3 = AdvSimd.ReverseElement8(v3);
+            v4 = AdvSimd.ReverseElement8(v4);
+            v0 = Aes.Encrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v3.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v4.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v3 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v4 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+            v3 = AdvSimd.ReverseElement8(v3);
+            v4 = AdvSimd.ReverseElement8(v4);
+            v0 = Aes.Encrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v3.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v4.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+
+            if (keylen == 44)
+            {
+                goto doLast;
+            }
+
+            v0 = Aes.Encrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+
+            if (keylen == 52)
+            {
+                goto doLast;
+            }
+
+            v0 = Aes.Encrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v2.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+
+            v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v2 = AdvSimd.ReverseElement8(v2);
+
+        doLast:;
+
+            v0 = Aes.Encrypt(v0, v1.AsByte());
+            v0 = Aes.InverseMixColumns(v0);
+            v0 = Aes.Encrypt(v0, v2.AsByte());
+
+            v1 = Vector128Util.LoadUnsafe(ref MemoryMarshal.GetReference(key));
+            v1 = AdvSimd.ReverseElement8(v1);
+            v0 = AdvSimd.Xor(v0, v1.AsByte());
 
             v0.CopyTo(to);
         }

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
@@ -11,6 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// Arm implementation of the AES intrinsic functions.
     /// </summary>
+    [SkipLocalsInit]
     static class AESCrypt_Arm
     {
         /// <summary>

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_Arm.cs
@@ -11,7 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// Arm implementation of the AES intrinsic functions.
     /// </summary>
-    unsafe static class AESCrypt_Arm
+    static class AESCrypt_Arm
     {
         /// <summary>
         /// Returns <c>true</c> if the current platform is supported by this implementation.

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_x86.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/AESCrypt_x86.cs
@@ -12,6 +12,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// X86 implementation of the AES intrinsic functions.
     /// </summary>
+    [SkipLocalsInit]
     static class AESCrypt_x86
     {
 

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining.cs
@@ -57,6 +57,14 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
                 CipherBlockChaining_x86.DecryptAESCrypt(cipher.AsSpan(cipherOffset), plain.AsSpan(plainOffset), k, r, cipherLen);
                 return true;
             }
+
+#if NET6_0_OR_GREATER
+            if (CipherBlockChaining_Arm.IsSupported)
+            {
+                CipherBlockChaining_Arm.DecryptAESCrypt(cipher.AsSpan(cipherOffset), plain.AsSpan(plainOffset), k, r, cipherLen);
+                return true;
+            }
+#endif
 #endif
 
             return false;

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining.cs
@@ -35,7 +35,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <param name="plainOffset"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool DecryptAESCrypt(object self, byte[] cipher, int cipherOffset, int cipherLen, byte[] plain, int plainOffset)
+        public static int DecryptAESCrypt(object self, byte[] cipher, int cipherOffset, int cipherLen, byte[] plain, int plainOffset)
         {
 #if FIRST_PASS
             throw new NotImplementedException();
@@ -47,27 +47,25 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
                 embeddedCipher: global::com.sun.crypto.provider.AESCrypt aes
             })
             {
-                return false;
+                return -1;
             }
 
             var k = AESCryptAccessor.K(aes);
 
             if (CipherBlockChaining_x86.IsSupported)
             {
-                CipherBlockChaining_x86.DecryptAESCrypt(cipher.AsSpan(cipherOffset), plain.AsSpan(plainOffset), k, r, cipherLen);
-                return true;
+                return CipherBlockChaining_x86.DecryptAESCrypt(cipher.AsSpan(cipherOffset), plain.AsSpan(plainOffset), k, r, cipherLen);
             }
 
 #if NET6_0_OR_GREATER
             if (CipherBlockChaining_Arm.IsSupported)
             {
-                CipherBlockChaining_Arm.DecryptAESCrypt(cipher.AsSpan(cipherOffset), plain.AsSpan(plainOffset), k, r, cipherLen);
-                return true;
+                return CipherBlockChaining_Arm.DecryptAESCrypt(cipher.AsSpan(cipherOffset), plain.AsSpan(plainOffset), k, r, cipherLen);
             }
 #endif
 #endif
 
-            return false;
+            return -1;
 #endif
         }
 
@@ -84,7 +82,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <param name="cipherOffset"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EncryptAESCrypt(object self, byte[] plain, int plainOffset, int plainLen, byte[] cipher, int cipherOffset)
+        public static int EncryptAESCrypt(object self, byte[] plain, int plainOffset, int plainLen, byte[] cipher, int cipherOffset)
         {
 #if FIRST_PASS
             throw new NotImplementedException();
@@ -96,19 +94,18 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
                     embeddedCipher: global::com.sun.crypto.provider.AESCrypt aes
                 })
             {
-                return false;
+                return -1;
             }
 
             var k = AESCryptAccessor.K(aes);
 
             if (AESCrypt_x86.IsSupported)
             {
-                CipherBlockChaining_x86.EncryptAESCrypt(plain.AsSpan(plainOffset), cipher.AsSpan(cipherOffset), k, r, plainLen);
-                return true;
+                return CipherBlockChaining_x86.EncryptAESCrypt(plain.AsSpan(plainOffset), cipher.AsSpan(cipherOffset), k, r, plainLen);
             }
 #endif
 
-            return false;
+            return -1;
 #endif
         }
 

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining.cs
@@ -103,6 +103,13 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             {
                 return CipherBlockChaining_x86.EncryptAESCrypt(plain.AsSpan(plainOffset), cipher.AsSpan(cipherOffset), k, r, plainLen);
             }
+
+#if NET6_0_OR_GREATER
+            if (CipherBlockChaining_Arm.IsSupported)
+            {
+                return CipherBlockChaining_Arm.EncryptAESCrypt(plain.AsSpan(plainOffset), cipher.AsSpan(cipherOffset), k, r, plainLen);
+            }
+#endif
 #endif
 
             return -1;

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
@@ -125,6 +125,105 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         finish:;
             return rscratch2;
         }
+
+        /// <summary>
+        /// Implementation of com.sun.crypto.provider.CipherBlockChaining.implEncrypt for the Arm platform.
+        /// Derived from the OpenJDK C code 'stubGenerator_aarch64.cpp:generate_cipherBlockChaining_encryptAESCrypt'.
+        /// Keep the structure of the body of this method as close to the orignal C code as possible to facilitate porting changes.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="key"></param>
+        /// <param name="rvec"></param>
+        /// <param name="length"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int EncryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
+        {
+            int rscratch2 = length;
+            if (rscratch2 == 0)
+            {
+                goto finish;
+            }
+
+            var keylen = key.Length;
+
+            var v0 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(rvec));
+
+            Unsafe.SkipInit(out Vector128<int> v17);
+            Unsafe.SkipInit(out Vector128<int> v18);
+            Unsafe.SkipInit(out Vector128<int> v19);
+            Unsafe.SkipInit(out Vector128<int> v20);
+
+            switch (keylen)
+            {
+                case < 52: goto loadkeys_44;
+                case 52: goto loadkeys_52;
+            }
+
+            (v17, v18) = Vector128Util.Load2xUnsafe(in RefUtils.Post(ref key, 32));
+            v17 = AdvSimd.ReverseElement8(v17);
+            v18 = AdvSimd.ReverseElement8(v18);
+        loadkeys_52:;
+            (v19, v20) = Vector128Util.Load2xUnsafe(in RefUtils.Post(ref key, 32));
+            v19 = AdvSimd.ReverseElement8(v19);
+            v20 = AdvSimd.ReverseElement8(v20);
+        loadkeys_44:;
+            var (v21, v22, v23, v24) = Vector128Util.Load4xUnsafe(in RefUtils.Post(ref key, 64));
+            v21 = AdvSimd.ReverseElement8(v21);
+            v22 = AdvSimd.ReverseElement8(v22);
+            v23 = AdvSimd.ReverseElement8(v23);
+            v24 = AdvSimd.ReverseElement8(v24);
+            var (v25, v26, v27, v28) = Vector128Util.Load4xUnsafe(in RefUtils.Post(ref key, 64));
+            v25 = AdvSimd.ReverseElement8(v25);
+            v26 = AdvSimd.ReverseElement8(v26);
+            v27 = AdvSimd.ReverseElement8(v27);
+            v28 = AdvSimd.ReverseElement8(v28);
+            var (v29, v30, v31) = Vector128Util.Load3xUnsafe(in MemoryMarshal.GetReference(key));
+            v29 = AdvSimd.ReverseElement8(v29);
+            v30 = AdvSimd.ReverseElement8(v30);
+            v31 = AdvSimd.ReverseElement8(v31);
+
+        aes_loop:
+            var v1 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref from, 16));
+            v0 = AdvSimd.Xor(v0, v1);
+
+            switch (keylen)
+            {
+                case < 52: goto rounds_44;
+                case 52: goto rounds_52;
+            }
+
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v17.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v18.AsByte()));
+        rounds_52:;
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v19.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v20.AsByte()));
+        rounds_44:;
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v21.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v22.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v23.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v24.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v25.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v26.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v27.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v28.AsByte()));
+            v0 = Aes.MixColumns(Aes.Encrypt(v0, v29.AsByte()));
+            v0 = Aes.Encrypt(v0, v30.AsByte());
+            v0 = AdvSimd.Xor(v0, v31.AsByte());
+
+            v0.StoreUnsafe(ref RefUtils.Post(ref to, 16));
+
+            if ((length -= 16) != 0)
+            {
+                goto aes_loop;
+            }
+
+            v0.CopyTo(rvec);
+
+        finish:;
+            return rscratch2;
+        }
     }
 }
 

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
@@ -1,0 +1,127 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+
+namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
+{
+    /// <summary>
+    /// Arm implementations of the CipherBlockChaining intrinsic functions.
+    /// </summary>
+    static class CipherBlockChaining_Arm
+    {
+
+        /// <summary>
+        /// Returns <c>true</c> if the current platform is supported by this implementation.
+        /// </summary>
+        public static bool IsSupported => AESCrypt_Arm.IsSupported;
+
+        /// <summary>
+        /// Implementation of com.sun.crypto.provider.CipherBlockChaining.implDecrypt for the Arm platform.
+        /// Derived from the OpenJDK C code 'stubGenerator_aarch64.cpp:generate_cipherBlockChaining_decryptAESCrypt'.
+        /// Keep the structure of the body of this method as close to the orignal C code as possible to facilitate porting changes.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="key"></param>
+        /// <param name="rvec"></param>
+        /// <param name="length"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void DecryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
+        {
+            if (length == 0)
+            {
+                goto finish;
+            }
+
+            var keylen = key.Length;
+
+            var v2 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(rvec));
+
+            var v31 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref key, 16));
+            v31 = AdvSimd.ReverseElement8(v31);
+
+            // Initialize Values, due to branching below,
+            // these are - for csc - unassigned, when
+            // setting the value in the branch.
+            Unsafe.SkipInit(out Vector128<int> v17);
+            Unsafe.SkipInit(out Vector128<int> v18);
+            Unsafe.SkipInit(out Vector128<int> v19);
+            Unsafe.SkipInit(out Vector128<int> v20);
+
+            switch (keylen)
+            {
+                case < 52: goto loadKeys_44;
+                case 52: goto loadKeys_52;
+            }
+
+            (v17, v18) = Vector128Util.Load2xUnsafe(in RefUtils.Post(ref key, 32));
+            v17 = AdvSimd.ReverseElement8(v17);
+            v18 = AdvSimd.ReverseElement8(v18);
+        loadKeys_52:;
+            (v19, v20) = Vector128Util.Load2xUnsafe(in RefUtils.Post(ref key, 32));
+            v19 = AdvSimd.ReverseElement8(v19);
+            v20 = AdvSimd.ReverseElement8(v20);
+        loadKeys_44:;
+            var (v21, v22, v23, v24) = Vector128Util.Load4xUnsafe(in RefUtils.Post(ref key, 64));
+            v21 = AdvSimd.ReverseElement8(v21);
+            v22 = AdvSimd.ReverseElement8(v22);
+            v23 = AdvSimd.ReverseElement8(v23);
+            v24 = AdvSimd.ReverseElement8(v24);
+            var (v25, v26, v27, v28) = Vector128Util.Load4xUnsafe(in RefUtils.Post(ref key, 64));
+            v25 = AdvSimd.ReverseElement8(v25);
+            v26 = AdvSimd.ReverseElement8(v26);
+            v27 = AdvSimd.ReverseElement8(v27);
+            v28 = AdvSimd.ReverseElement8(v28);
+            var (v29, v30) = Vector128Util.Load2xUnsafe(in MemoryMarshal.GetReference(key));
+            v29 = AdvSimd.ReverseElement8(v29);
+            v30 = AdvSimd.ReverseElement8(v30);
+
+        aes_loop:;
+            var v0 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref from, 16));
+            var v1 = AdvSimd.Or(v0, v0);
+
+            switch (keylen)
+            {
+                case < 52: goto rounds_44;
+                case 52: goto rounds_52;
+            }
+
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v17.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v18.AsByte()));
+        rounds_52:;
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v19.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v20.AsByte()));
+        rounds_44:;
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v21.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v22.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v23.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v24.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v25.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v26.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v27.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v28.AsByte()));
+            v0 = Aes.InverseMixColumns(Aes.Decrypt(v0, v29.AsByte()));
+            v0 = Aes.Decrypt(v0, v30.AsByte());
+            v0 = AdvSimd.Xor(v0, v31.AsByte());
+            v0 = AdvSimd.Xor(v0, v2.AsByte());
+
+            v0.StoreUnsafe(ref RefUtils.Post(ref to, 16));
+            v2 = AdvSimd.Or(v1, v1);
+
+            if ((length -= 16) != 0)
+            {
+                goto aes_loop;
+            }
+
+            v2.CopyTo(rvec);
+
+        finish:;
+        }
+    }
+}
+
+#endif

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
@@ -30,10 +30,12 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <param name="key"></param>
         /// <param name="rvec"></param>
         /// <param name="length"></param>
+        /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DecryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
+        public static int DecryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
         {
-            if (length == 0)
+            int rscratch2 = length;
+            if (rscratch2 == 0)
             {
                 goto finish;
             }
@@ -55,18 +57,18 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
 
             switch (keylen)
             {
-                case < 52: goto loadKeys_44;
-                case 52: goto loadKeys_52;
+                case < 52: goto loadkeys_44;
+                case 52: goto loadkeys_52;
             }
 
             (v17, v18) = Vector128Util.Load2xUnsafe(in RefUtils.Post(ref key, 32));
             v17 = AdvSimd.ReverseElement8(v17);
             v18 = AdvSimd.ReverseElement8(v18);
-        loadKeys_52:;
+        loadkeys_52:;
             (v19, v20) = Vector128Util.Load2xUnsafe(in RefUtils.Post(ref key, 32));
             v19 = AdvSimd.ReverseElement8(v19);
             v20 = AdvSimd.ReverseElement8(v20);
-        loadKeys_44:;
+        loadkeys_44:;
             var (v21, v22, v23, v24) = Vector128Util.Load4xUnsafe(in RefUtils.Post(ref key, 64));
             v21 = AdvSimd.ReverseElement8(v21);
             v22 = AdvSimd.ReverseElement8(v22);
@@ -121,6 +123,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             v2.CopyTo(rvec);
 
         finish:;
+            return rscratch2;
         }
     }
 }

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
@@ -34,6 +34,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int DecryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
         {
+            // ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:2606-2699
             int rscratch2 = length;
             if (rscratch2 == 0)
             {
@@ -140,6 +141,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int EncryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
         {
+            // ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:2713-2805
             int rscratch2 = length;
             if (rscratch2 == 0)
             {

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_Arm.cs
@@ -11,6 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// Arm implementations of the CipherBlockChaining intrinsic functions.
     /// </summary>
+    [SkipLocalsInit]
     static class CipherBlockChaining_Arm
     {
 

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_x86.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_x86.cs
@@ -12,6 +12,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// X86 implementations of the CipherBlockChaining intrinsic functions.
     /// </summary>
+    [SkipLocalsInit]
     static class CipherBlockChaining_x86
     {
 

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_x86.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/CipherBlockChaining_x86.cs
@@ -33,8 +33,9 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <param name="key"></param>
         /// <param name="rvec"></param>
         /// <param name="length"></param>
+        /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DecryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
+        public static int DecryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
         {
             const int XMM_REG_NUM_KEY_FIRST = 2;
             const int XMM_REG_NUM_KEY_LAST = 7;
@@ -89,7 +90,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
 
         exit:;
             Unsafe.CopyBlockUnaligned(ref MemoryMarshal.GetReference(rvec), ref prev_block_cipher_ptr, 16);
-            return;
+            return (int)pos;
 
         key_192_256:;
             if (key.Length != 52)
@@ -165,8 +166,9 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <param name="key"></param>
         /// <param name="rvec"></param>
         /// <param name="length"></param>
+        /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void EncryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
+        public static int EncryptAESCrypt(ReadOnlySpan<byte> from, Span<byte> to, ReadOnlySpan<int> key, Span<byte> rvec, int length)
         {
             // ext\openjdk\hotspot\src\cpu\x86\vm\stubGenerator_x86_32.cpp:2410-2549
             var xmm_key_shuf_mask = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(AESCrypt_x86.KeyShuffleMask)).AsByte();
@@ -216,7 +218,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
 
         exit:
             xmm_result.StoreUnsafe(ref MemoryMarshal.GetReference(rvec));
-            return;
+            return (int)pos;
 
         key_192_256:;
             if (key.Length != 52)

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH.cs
@@ -33,9 +33,17 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
 #if NETCOREAPP3_0_OR_GREATER
             if (GHASH_x86.IsSupported)
             {
-                GHASH_x86.ProcessBlocks(data.AsSpan(inOfs), blocks, st, subH);
+                GHASH_x86.ProcessBlocks(st, subH, data.AsSpan(inOfs), blocks);
                 return true;
             }
+
+#if NET6_0_OR_GREATER
+            if (GHASH_Arm64.IsSupported)
+            {
+                GHASH_Arm64.ProcessBlocks(st, subH, data.AsSpan(inOfs), blocks);
+                return true;
+            }
+#endif
 #endif
 
             return false;

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
@@ -48,8 +48,8 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             v16 = AdvSimd.Xor(v16, v1);
 
             {
-            ghash_loop:
-                var v2 = Vector128Util.LoadUnsafe(in Post(ref data, 0x10));
+            ghash_loop:;
+                var v2 = Vector128Util.LoadUnsafe(in RefUtils.Post(ref data, 0x10));
                 v2 = AdvSimd.Arm64.ReverseElementBits(v2);
                 v2 = AdvSimd.Xor(v0.AsByte(), v2);
 
@@ -99,13 +99,6 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             lo = AdvSimd.Xor(lo, t1.AsInt64());
             t0 = Aes.PolynomialMultiplyWideningLower(hi.GetLower(), p.GetLower());
             return AdvSimd.Xor(lo, t0);
-        }
-
-        private static ref T Post<T>(ref ReadOnlySpan<T> data, nint offset)
-        {
-            ref T source = ref MemoryMarshal.GetReference(data);
-            data = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AddByteOffset(ref source, offset), data.Length - (int)offset);
-            return ref source;
         }
     }
 }

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
@@ -1,0 +1,113 @@
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+
+namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
+{
+    /// <summary>
+    /// Arm implementation of the GHASH intrinsic functions.
+    /// </summary>
+    static class GHASH_Arm64
+    {
+        private static ReadOnlySpan<long> P => [0x87, 0x87];
+
+        /// <summary>
+        /// Returns <c>true</c> if the current platform is supported by this implementation.
+        /// </summary>
+        public static bool IsSupported => Aes.IsSupported && AdvSimd.Arm64.IsSupported;
+
+        /// <summary>
+        /// Implementation of com.sun.crypto.provider.GHASH.processBlocks for the Arm platform.
+        /// Derived from the OpenJDK C code 'stubGenerator_aarch64.cpp:generate_ghash_processBlocks'.
+        /// Keep the structure of the body of this method as close to the orignal C code as possible to facilitate porting changes.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <param name="subH"></param>
+        /// <param name="data"></param>
+        /// <param name="blocks"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe static void ProcessBlocks(Span<long> state, ReadOnlySpan<long> subH, ReadOnlySpan<byte> data, int blocks)
+        {
+            // ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:3322-3395
+            var vzr = Vector128<byte>.Zero;
+
+            var v0 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(state));
+            var v1 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(subH));
+            v0 = AdvSimd.ReverseElement8(v0);
+            v0 = AdvSimd.Arm64.ReverseElementBits(v0.AsByte()).AsInt64();
+            v1 = AdvSimd.ReverseElement8(v1);
+            v1 = AdvSimd.Arm64.ReverseElementBits(v1.AsByte()).AsInt64();
+
+            var v26 = Vector128Util.LoadUnsafe(in MemoryMarshal.GetReference(P));
+
+            var v16 = AdvSimd.ExtractVector128(v1.AsByte(), v1.AsByte(), 0x08).AsInt64();
+            v16 = AdvSimd.Xor(v16, v1);
+
+            {
+            ghash_loop:
+                var v2 = Vector128Util.LoadUnsafe(in Post(ref data, 0x10));
+                v2 = AdvSimd.Arm64.ReverseElementBits(v2);
+                v2 = AdvSimd.Xor(v0.AsByte(), v2);
+
+                (var v5, var v7) = GHashMultiply(v1, v2, v16);
+                v0 = GHashReduce(v5, v7, v26, vzr);
+
+                if ((--blocks) != 0)
+                {
+                    goto ghash_loop;
+                }
+            }
+
+            v1 = AdvSimd.ReverseElement8(v0);
+            v1 = AdvSimd.Arm64.ReverseElementBits(v1.AsByte()).AsInt64();
+            v1.CopyTo(state);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static (Vector128<long> Lower, Vector128<long> Upper) GHashMultiply(Vector128<long> a, Vector128<byte> b, Vector128<long> a1_xor_a0)
+        {
+            // ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:3207-3240
+            var tmp1 = AdvSimd.ExtractVector128(b, b, 0x08);
+            var result_hi = Aes.PolynomialMultiplyWideningUpper(b.AsInt64(), a);
+            tmp1 = AdvSimd.Xor(tmp1, b);
+            var result_lo = Aes.PolynomialMultiplyWideningLower(b.GetLower().AsInt64(), a.GetLower());
+            var tmp2 = Aes.PolynomialMultiplyWideningLower(tmp1.GetLower().AsInt64(), a1_xor_a0.GetLower());
+
+            var tmp4 = AdvSimd.ExtractVector128(result_lo.AsByte(), result_hi.AsByte(), 0x08);
+            var tmp3 = AdvSimd.Xor(result_hi, result_lo);
+            tmp2 = AdvSimd.Xor(tmp2, tmp4.AsInt64());
+            tmp2 = AdvSimd.Xor(tmp2, tmp3);
+
+            result_hi = AdvSimd.Arm64.InsertSelectedScalar(result_hi, 0, tmp2, 1);
+            result_lo = AdvSimd.Arm64.InsertSelectedScalar(result_lo, 1, tmp2, 0);
+
+            return (result_lo, result_hi);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<long> GHashReduce(Vector128<long> lo, Vector128<long> hi, Vector128<long> p, Vector128<byte> z)
+        {
+            // ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:3242-3268
+            var t0 = Aes.PolynomialMultiplyWideningUpper(hi, p);
+            var t1 = AdvSimd.ExtractVector128(t0.AsByte(), z, 8);
+            hi = AdvSimd.Xor(hi, t1.AsInt64());
+            t1 = AdvSimd.ExtractVector128(z, t0.AsByte(), 8);
+            lo = AdvSimd.Xor(lo, t1.AsInt64());
+            t0 = Aes.PolynomialMultiplyWideningLower(hi.GetLower(), p.GetLower());
+            return AdvSimd.Xor(lo, t0);
+        }
+
+        private static ref T Post<T>(ref ReadOnlySpan<T> data, nint offset)
+        {
+            ref T source = ref MemoryMarshal.GetReference(data);
+            data = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AddByteOffset(ref source, offset), data.Length - (int)offset);
+            return ref source;
+        }
+    }
+}
+
+#endif

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
@@ -30,7 +30,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <param name="data"></param>
         /// <param name="blocks"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe static void ProcessBlocks(Span<long> state, ReadOnlySpan<long> subH, ReadOnlySpan<byte> data, int blocks)
+        public static void ProcessBlocks(Span<long> state, ReadOnlySpan<long> subH, ReadOnlySpan<byte> data, int blocks)
         {
             // ext\openjdk\hotspot\src\cpu\aarch64\vm\stubGenerator_aarch64.cpp:3322-3395
             var vzr = Vector128<byte>.Zero;

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
@@ -11,6 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// Arm implementation of the GHASH intrinsic functions.
     /// </summary>
+    [SkipLocalsInit]
     static class GHASH_Arm64
     {
         private static ReadOnlySpan<long> P => [0x87, 0x87];

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_Arm64.cs
@@ -18,7 +18,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <summary>
         /// Returns <c>true</c> if the current platform is supported by this implementation.
         /// </summary>
-        public static bool IsSupported => Aes.IsSupported && AdvSimd.Arm64.IsSupported;
+        public static bool IsSupported => BitConverter.IsLittleEndian && Aes.IsSupported && AdvSimd.Arm64.IsSupported;
 
         /// <summary>
         /// Implementation of com.sun.crypto.provider.GHASH.processBlocks for the Arm platform.

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_x86.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_x86.cs
@@ -29,12 +29,12 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// Derived from the OpenJDK C code 'stubGenerator_x86_32.cpp:generate_ghash_processBlocks'.
         /// Keep the structure of the body of this method as close to the orignal C code as possible to facilitate porting changes.
         /// </summary>
-        /// <param name="data"></param>
-        /// <param name="blocks"></param>
         /// <param name="state"></param>
         /// <param name="subH"></param>
+        /// <param name="data"></param>
+        /// <param name="blocks"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ProcessBlocks(ReadOnlySpan<byte> data, int blocks, Span<long> state, ReadOnlySpan<long> subH)
+        public static void ProcessBlocks(Span<long> state, ReadOnlySpan<long> subH, ReadOnlySpan<byte> data, int blocks)
         {
             // ext\openjdk\hotspot\src\cpu\x86\vm\stubGenerator_x86_32.cpp:2748-2883
             Vector128<int> xmm_temp0, xmm_temp1, xmm_temp2, xmm_temp3, xmm_temp4, xmm_temp5, xmm_temp6, xmm_temp7;

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_x86.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/GHASH_x86.cs
@@ -12,6 +12,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// X86 implementation of the GHASH intrinsic functions.
     /// </summary>
+    [SkipLocalsInit]
     static class GHASH_x86
     {
 

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/RefUtils.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/RefUtils.cs
@@ -1,0 +1,27 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
+{
+    unsafe static class RefUtils
+    {
+        public static ref T Post<T>(ref Span<T> data, nint byteOffset) where T : unmanaged
+        {
+            ref T element = ref MemoryMarshal.GetReference(data);
+            data = MemoryMarshal.CreateSpan(ref Unsafe.AddByteOffset(ref element, byteOffset), data.Length - (int)(byteOffset / sizeof(T)));
+            return ref element;
+        }
+
+        public static ref T Post<T>(ref ReadOnlySpan<T> data, nint byteOffset) where T : unmanaged
+        {
+            ref T element = ref MemoryMarshal.GetReference(data);
+            data = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AddByteOffset(ref element, byteOffset), data.Length - (int)(byteOffset / sizeof(T)));
+            return ref element;
+        }
+    }
+}
+
+#endif

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/RefUtils.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/RefUtils.cs
@@ -8,17 +8,27 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
 {
     unsafe static class RefUtils
     {
-        public static ref T Post<T>(ref Span<T> data, nint byteOffset) where T : unmanaged
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T Post<T>(ref Span<T> data, nint byteOffset) where T : struct
         {
             ref T element = ref MemoryMarshal.GetReference(data);
-            data = MemoryMarshal.CreateSpan(ref Unsafe.AddByteOffset(ref element, byteOffset), data.Length - (int)(byteOffset / sizeof(T)));
+#if NET8_0_OR_GREATER
+            data = new(ref Unsafe.AddByteOffset(ref element, byteOffset));
+#else
+            data = MemoryMarshal.CreateSpan(ref Unsafe.AddByteOffset(ref element, byteOffset), 1);
+#endif
             return ref element;
         }
 
-        public static ref T Post<T>(ref ReadOnlySpan<T> data, nint byteOffset) where T : unmanaged
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T Post<T>(ref ReadOnlySpan<T> data, nint byteOffset) where T : struct
         {
             ref T element = ref MemoryMarshal.GetReference(data);
-            data = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AddByteOffset(ref element, byteOffset), data.Length - (int)(byteOffset / sizeof(T)));
+#if NET8_0_OR_GREATER
+            data = new(in Unsafe.AddByteOffset(ref element, byteOffset));
+#else
+            data = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AddByteOffset(ref element, byteOffset), 1);
+#endif
             return ref element;
         }
     }

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/RefUtils.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/RefUtils.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
 {
-    unsafe static class RefUtils
+    static class RefUtils
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T Post<T>(ref Span<T> data, nint byteOffset) where T : struct

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/Vector128Util.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/Vector128Util.cs
@@ -11,7 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// Provides wrappers for methods from <see cref="Vector128{T}"/> backfilling their implementation on non-supporting Frameworks.
     /// </summary>
-    unsafe static class Vector128Util
+    static class Vector128Util
     {
 
         /// <summary>

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/Vector128Util.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/Vector128Util.cs
@@ -11,7 +11,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
     /// <summary>
     /// Provides wrappers for methods from <see cref="Vector128{T}"/> backfilling their implementation on non-supporting Frameworks.
     /// </summary>
-    static class Vector128Util
+    unsafe static class Vector128Util
     {
 
         /// <summary>
@@ -50,6 +50,54 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
 
             return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
 #endif
+        }
+
+        /// <summary>
+        /// Loads two consecutive vectors from given source.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (Vector128<T> V1, Vector128<T> V2) Load2xUnsafe<T>(ref readonly T source) where T : struct
+        {
+            return (
+                LoadUnsafe(in source, 0 * (nuint)Vector128<T>.Count),
+                LoadUnsafe(in source, 1 * (nuint)Vector128<T>.Count)
+            );
+        }
+
+        /// <summary>
+        /// Loads three consecutive vectors from given source.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (Vector128<T> V1, Vector128<T> V2, Vector128<T> V3) Load3x<T>(ref readonly T source) where T : struct
+        {
+            return (
+                LoadUnsafe(in source, 0 * (nuint)Vector128<T>.Count),
+                LoadUnsafe(in source, 1 * (nuint)Vector128<T>.Count),
+                LoadUnsafe(in source, 2 * (nuint)Vector128<T>.Count)
+            );
+        }
+
+        /// <summary>
+        /// Loads four consecutive vectors from given source.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (Vector128<T> V1, Vector128<T> V2, Vector128<T> V3, Vector128<T> V4) Load4xUnsafe<T>(ref readonly T source) where T : struct
+        {
+            return (
+                LoadUnsafe(in source, 0 * (nuint)Vector128<T>.Count),
+                LoadUnsafe(in source, 1 * (nuint)Vector128<T>.Count),
+                LoadUnsafe(in source, 2 * (nuint)Vector128<T>.Count),
+                LoadUnsafe(in source, 3 * (nuint)Vector128<T>.Count)
+            );
         }
 
         /// <summary>
@@ -129,9 +177,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
             Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
 #endif
         }
-
     }
-
 }
 
 #endif

--- a/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/Vector128Util.cs
+++ b/src/IKVM.Runtime/Util/Com/Sun/Crypto/Provider/Vector128Util.cs
@@ -74,7 +74,7 @@ namespace IKVM.Runtime.Util.Com.Sun.Crypto.Provider
         /// <param name="source"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (Vector128<T> V1, Vector128<T> V2, Vector128<T> V3) Load3x<T>(ref readonly T source) where T : struct
+        public static (Vector128<T> V1, Vector128<T> V2, Vector128<T> V3) Load3xUnsafe<T>(ref readonly T source) where T : struct
         {
             return (
                 LoadUnsafe(in source, 0 * (nuint)Vector128<T>.Count),


### PR DESCRIPTION
Some results:
- M1: x3 on CTR, x4 for CBC compared to Zulu8 JRE
- Ampere: 70% of JRE for CTR, 60% of JRE for CBC
Was: 25% for CTR, 6% for CBC

With these changes (SkipLocalsInit) IKVM is 10% faster then Adoptium JRE8 for CTR.

Fixes #390