### PR TITLE
NET472 tool support on Unix

### DIFF
--- a/src/IKVM.MSBuild.Tools.runtime.linux-x64/IKVM.MSBuild.Tools.runtime.linux-x64.csproj
+++ b/src/IKVM.MSBuild.Tools.runtime.linux-x64/IKVM.MSBuild.Tools.runtime.linux-x64.csproj
@@ -16,6 +16,22 @@
 
     <ItemGroup>
         <PublishProjectReference Include="..\ikvmc\ikvmc.csproj">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=linux-x64</SetRuntimeIdentifier>
+            <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmc\net472\linux-x64</PublishTargetPath>
+            <CopyToOutputDirectory Condition=" '$(TargetFramework)' != '' ">PreserveNewest</CopyToOutputDirectory>
+            <PublishPackagePath>ikvmc\net472\linux-x64</PublishPackagePath>
+            <Pack>true</Pack>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmstub\ikvmstub.csproj">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=linux-x64</SetRuntimeIdentifier>
+            <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmstub\net472\linux-x64</PublishTargetPath>
+            <CopyToOutputDirectory Condition=" '$(TargetFramework)' != '' ">PreserveNewest</CopyToOutputDirectory>
+            <PublishPackagePath>ikvmstub\net472\linux-x64</PublishPackagePath>
+            <Pack>true</Pack>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmc\ikvmc.csproj">
             <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
             <SetRuntimeIdentifier>RuntimeIdentifier=linux-x64</SetRuntimeIdentifier>
             <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmc\net8.0\linux-x64</PublishTargetPath>

--- a/src/IKVM.MSBuild.Tools.runtime.linux-x64/buildTransitive/IKVM.MSBuild.Tools.runtime.linux-x64.props
+++ b/src/IKVM.MSBuild.Tools.runtime.linux-x64/buildTransitive/IKVM.MSBuild.Tools.runtime.linux-x64.props
@@ -4,7 +4,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <IkvmCompilerToolPath Include="$(MSBuildThisFileDirectory)..\ikvmc\net472\linux-x64\" TargetFramework="net472" RuntimeIdentifier="linux-x64" />
         <IkvmCompilerToolPath Include="$(MSBuildThisFileDirectory)..\ikvmc\net8.0\linux-x64\" TargetFramework="net8.0" RuntimeIdentifier="linux-x64" />
+        <IkvmExporterToolPath Include="$(MSBuildThisFileDirectory)..\ikvmstub\net472\linux-x64\" TargetFramework="net472" RuntimeIdentifier="linux-x64" />
         <IkvmExporterToolPath Include="$(MSBuildThisFileDirectory)..\ikvmstub\net8.0\linux-x64\" TargetFramework="net8.0" RuntimeIdentifier="linux-x64" />
     </ItemGroup>
     

--- a/src/IKVM.MSBuild.Tools.runtime.osx-arm64/IKVM.MSBuild.Tools.runtime.osx-arm64.csproj
+++ b/src/IKVM.MSBuild.Tools.runtime.osx-arm64/IKVM.MSBuild.Tools.runtime.osx-arm64.csproj
@@ -16,6 +16,22 @@
 
     <ItemGroup>
         <PublishProjectReference Include="..\ikvmc\ikvmc.csproj">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=osx-arm64</SetRuntimeIdentifier>
+            <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmc\net472\osx-arm64</PublishTargetPath>
+            <CopyToOutputDirectory Condition=" '$(TargetFramework)' != '' ">PreserveNewest</CopyToOutputDirectory>
+            <PublishPackagePath>ikvmc\net472\osx-arm64</PublishPackagePath>
+            <Pack>true</Pack>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmstub\ikvmstub.csproj">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=osx-arm64</SetRuntimeIdentifier>
+            <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmstub\net472\osx-arm64</PublishTargetPath>
+            <CopyToOutputDirectory Condition=" '$(TargetFramework)' != '' ">PreserveNewest</CopyToOutputDirectory>
+            <PublishPackagePath>ikvmstub\net472\osx-arm64</PublishPackagePath>
+            <Pack>true</Pack>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmc\ikvmc.csproj">
             <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
             <SetRuntimeIdentifier>RuntimeIdentifier=osx-arm64</SetRuntimeIdentifier>
             <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmc\net8.0\osx-arm64</PublishTargetPath>

--- a/src/IKVM.MSBuild.Tools.runtime.osx-arm64/buildTransitive/IKVM.MSBuild.Tools.runtime.osx-arm64.props
+++ b/src/IKVM.MSBuild.Tools.runtime.osx-arm64/buildTransitive/IKVM.MSBuild.Tools.runtime.osx-arm64.props
@@ -4,7 +4,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <IkvmCompilerToolPath Include="$(MSBuildThisFileDirectory)..\ikvmc\net472\osx-arm64\" TargetFramework="net472" RuntimeIdentifier="osx-arm64" />
         <IkvmCompilerToolPath Include="$(MSBuildThisFileDirectory)..\ikvmc\net8.0\osx-arm64\" TargetFramework="net8.0" RuntimeIdentifier="osx-arm64" />
+        <IkvmExporterToolPath Include="$(MSBuildThisFileDirectory)..\ikvmstub\net472\osx-arm64\" TargetFramework="net472" RuntimeIdentifier="osx-arm64" />
         <IkvmExporterToolPath Include="$(MSBuildThisFileDirectory)..\ikvmstub\net8.0\osx-arm64\" TargetFramework="net8.0" RuntimeIdentifier="osx-arm64" />
     </ItemGroup>
 

--- a/src/IKVM.MSBuild.Tools.runtime.osx-x64/IKVM.MSBuild.Tools.runtime.osx-x64.csproj
+++ b/src/IKVM.MSBuild.Tools.runtime.osx-x64/IKVM.MSBuild.Tools.runtime.osx-x64.csproj
@@ -16,6 +16,22 @@
 
     <ItemGroup>
         <PublishProjectReference Include="..\ikvmc\ikvmc.csproj">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=osx-x64</SetRuntimeIdentifier>
+            <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmc\net472\osx-x64</PublishTargetPath>
+            <CopyToOutputDirectory Condition=" '$(TargetFramework)' != '' ">PreserveNewest</CopyToOutputDirectory>
+            <PublishPackagePath>ikvmc\net472\osx-x64</PublishPackagePath>
+            <Pack>true</Pack>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmstub\ikvmstub.csproj">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=osx-x64</SetRuntimeIdentifier>
+            <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmstub\net472\osx-x64</PublishTargetPath>
+            <CopyToOutputDirectory Condition=" '$(TargetFramework)' != '' ">PreserveNewest</CopyToOutputDirectory>
+            <PublishPackagePath>ikvmstub\net472\osx-x64</PublishPackagePath>
+            <Pack>true</Pack>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmc\ikvmc.csproj">
             <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
             <SetRuntimeIdentifier>RuntimeIdentifier=osx-x64</SetRuntimeIdentifier>
             <PublishTargetPath Condition=" '$(TargetFramework)' != '' ">ikvmc\net8.0\osx-x64</PublishTargetPath>

--- a/src/IKVM.MSBuild.Tools.runtime.osx-x64/buildTransitive/IKVM.MSBuild.Tools.runtime.osx-x64.props
+++ b/src/IKVM.MSBuild.Tools.runtime.osx-x64/buildTransitive/IKVM.MSBuild.Tools.runtime.osx-x64.props
@@ -4,7 +4,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <IkvmCompilerToolPath Include="$(MSBuildThisFileDirectory)..\ikvmc\net472\osx-x64\" TargetFramework="net472" RuntimeIdentifier="osx-x64" />
         <IkvmCompilerToolPath Include="$(MSBuildThisFileDirectory)..\ikvmc\net8.0\osx-x64\" TargetFramework="net8.0" RuntimeIdentifier="osx-x64" />
+        <IkvmExporterToolPath Include="$(MSBuildThisFileDirectory)..\ikvmstub\net472\osx-x64\" TargetFramework="net472" RuntimeIdentifier="osx-x64" />
         <IkvmExporterToolPath Include="$(MSBuildThisFileDirectory)..\ikvmstub\net8.0\osx-x64\" TargetFramework="net8.0" RuntimeIdentifier="osx-x64" />
     </ItemGroup>
     

--- a/src/IKVM.Tests.Util/DotNetSdkResolver.cs
+++ b/src/IKVM.Tests.Util/DotNetSdkResolver.cs
@@ -129,7 +129,7 @@ namespace IKVM.Tests.Util
             }
 
             var segments = lines[index]
-                .Split(['[', ']'], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { '[', ']' }, StringSplitOptions.RemoveEmptyEntries)
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .Select(x => x.Trim())
                 .ToArray();

--- a/src/IKVM.Tests.Util/DotNetSdkResolver.cs
+++ b/src/IKVM.Tests.Util/DotNetSdkResolver.cs
@@ -129,7 +129,7 @@ namespace IKVM.Tests.Util
             }
 
             var segments = lines[index]
-                .Split(new[] { '[', ']' }, StringSplitOptions.RemoveEmptyEntries)
+                .Split(['[', ']'], StringSplitOptions.RemoveEmptyEntries)
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .Select(x => x.Trim())
                 .ToArray();

--- a/src/IKVM.Tests.Util/DotNetSdkUtil.cs
+++ b/src/IKVM.Tests.Util/DotNetSdkUtil.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
-using Microsoft.Build.Utilities;
-
 namespace IKVM.Tests.Util
 {
 
@@ -63,11 +61,21 @@ namespace IKVM.Tests.Util
         public static IList<string> GetPathToReferenceAssemblies(string tfm, string targetFrameworkIdentifier, string targetFrameworkVersion)
         {
             if (targetFrameworkIdentifier == ".NETFramework")
-                return ToolLocationHelper.GetPathToReferenceAssemblies(targetFrameworkIdentifier, targetFrameworkVersion, "");
-            if (targetFrameworkIdentifier == ".NETCore")
-                return GetCorePathToReferenceAssemblies(tfm, targetFrameworkVersion);
+            {
+                var l = new List<string>();
+                var dir = Path.Combine(Path.GetDirectoryName(typeof(DotNetSdkUtil).Assembly.Location), "netfxref", tfm);
+                if (Directory.Exists(dir))
+                    l.Add(dir);
 
-            throw new InvalidOperationException();
+                return l;
+            }
+
+            if (targetFrameworkIdentifier == ".NETCore")
+            {
+                return GetCorePathToReferenceAssemblies(tfm, targetFrameworkVersion);
+            }
+
+            throw new ArgumentException(nameof(targetFrameworkIdentifier));
         }
 
         /// <summary>

--- a/src/IKVM.Tests.Util/IKVM.Tests.Util.csproj
+++ b/src/IKVM.Tests.Util/IKVM.Tests.Util.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+    
     <PropertyGroup>
         <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
@@ -8,5 +10,30 @@
         <PackageReference Include="Microsoft.Build" Version="17.3.2" />
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
         <PackageReference Include="System.Reflection.Metadata" Version="8.0.1" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net481" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
     </ItemGroup>
+
+    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+    <PropertyGroup>
+        <AssignTargetPathsDependsOn>
+            IncludeReferenceAssemblies;
+            $(AssignTargetPathsDependsOn)
+        </AssignTargetPathsDependsOn>
+    </PropertyGroup>
+
+    <Target Name="IncludeReferenceAssemblies" BeforeTargets="AssignTargetPaths">
+        <ItemGroup>
+            <__ReferenceAssemblies Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net472)\build\.NETFramework\v4.7.2\*.dll" Framework="net472" />
+            <__ReferenceAssemblies Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net472)\build\.NETFramework\v4.7.2\Facades\*.dll" Framework="net472" />
+            <__ReferenceAssemblies Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net481)\build\.NETFramework\v4.8.1\*.dll" Framework="net481" />
+            <__ReferenceAssemblies Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net481)\build\.NETFramework\v4.8.1\Facades\*.dll" Framework="net481" />
+            <None Include="@(__ReferenceAssemblies)">
+                <TargetPath>netfxref\%(Framework)\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+                <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            </None>
+        </ItemGroup>
+    </Target>
+    
 </Project>

--- a/src/IKVM.Tests.Util/IKVM.Tests.Util.csproj
+++ b/src/IKVM.Tests.Util/IKVM.Tests.Util.csproj
@@ -10,8 +10,8 @@
         <PackageReference Include="Microsoft.Build" Version="17.3.2" />
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
         <PackageReference Include="System.Reflection.Metadata" Version="8.0.1" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net481" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" GeneratePathProperty="true" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net481" Version="1.0.3" GeneratePathProperty="true" />
     </ItemGroup>
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/IKVM.Tools.Runner/IkvmToolLauncher.cs
+++ b/src/IKVM.Tools.Runner/IkvmToolLauncher.cs
@@ -92,44 +92,16 @@ namespace IKVM.Tools.Runner
         /// <summary>
         /// Gets the path to executable for the given environment.
         /// </summary>
-        /// <param name="platform"></param>
-        /// <param name="architecture"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="NotImplementedException"></exception>
-        public string GetToolExe(OSPlatform platform, Architecture architecture)
+        public string? GetToolExe()
         {
-            return Path.Combine(toolPath, platform == OSPlatform.Windows ? $"{toolName}.exe" : toolName);
-        }
+            foreach (var name in (Span<string>)[toolName + ".exe", toolName])
+                if (File.Exists(Path.Combine(toolPath, name)))
+                    return Path.Combine(toolPath, name);
 
-        /// <summary>
-        /// Gets the path to executable for the given environment.
-        /// </summary>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="NotImplementedException"></exception>
-        public string GetToolExe()
-        {
-            return GetToolExe(GetOSPlatform(), RuntimeInformation.OSArchitecture);
-        }
-
-        /// <summary>
-        /// Gets the current OS platform.
-        /// </summary>
-        /// <returns></returns>
-        /// <exception cref="PlatformNotSupportedException"></exception>
-        OSPlatform GetOSPlatform()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return OSPlatform.Windows;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                return OSPlatform.Linux;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return OSPlatform.OSX;
-
-            throw new PlatformNotSupportedException();
+            return null;
         }
 
     }

--- a/src/IKVM.Tools.Tests/IKVM.Tools.Tests.csproj
+++ b/src/IKVM.Tools.Tests/IKVM.Tools.Tests.csproj
@@ -109,6 +109,19 @@
         </PublishProjectReference>
 
         <PublishProjectReference Include="..\ikvmc\ikvmc.csproj" Condition="$(_EnabledImageRuntimes.Contains(';linux-x64;'))">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=linux-x64</SetRuntimeIdentifier>
+            <PublishTargetPath>ikvmc\net472\linux-x64</PublishTargetPath>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmstub\ikvmstub.csproj" Condition="$(_EnabledImageRuntimes.Contains(';linux-x64;'))">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=linux-x64</SetRuntimeIdentifier>
+            <PublishTargetPath>ikvmstub\net472\linux-x64</PublishTargetPath>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </PublishProjectReference>
+
+        <PublishProjectReference Include="..\ikvmc\ikvmc.csproj" Condition="$(_EnabledImageRuntimes.Contains(';linux-x64;'))">
             <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
             <SetRuntimeIdentifier>RuntimeIdentifier=linux-x64</SetRuntimeIdentifier>
             <PublishTargetPath>ikvmc\net8.0\linux-x64</PublishTargetPath>
@@ -118,6 +131,19 @@
             <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
             <SetRuntimeIdentifier>RuntimeIdentifier=linux-x64</SetRuntimeIdentifier>
             <PublishTargetPath>ikvmstub\net8.0\linux-x64</PublishTargetPath>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </PublishProjectReference>
+
+        <PublishProjectReference Include="..\ikvmc\ikvmc.csproj" Condition="$(_EnabledImageRuntimes.Contains(';osx-x64;'))">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=osx-x64</SetRuntimeIdentifier>
+            <PublishTargetPath>ikvmc\net472\osx-x64</PublishTargetPath>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </PublishProjectReference>
+        <PublishProjectReference Include="..\ikvmstub\ikvmstub.csproj" Condition="$(_EnabledImageRuntimes.Contains(';osx-x64;'))">
+            <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+            <SetRuntimeIdentifier>RuntimeIdentifier=osx-x64</SetRuntimeIdentifier>
+            <PublishTargetPath>ikvmstub\net472\osx-x64</PublishTargetPath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </PublishProjectReference>
 

--- a/src/IKVM.Tools.Tests/Runner/Exporter/IkvmExporterLauncherTests.cs
+++ b/src/IKVM.Tools.Tests/Runner/Exporter/IkvmExporterLauncherTests.cs
@@ -35,11 +35,6 @@ namespace IKVM.Tools.Tests.Runner.Exporter
         [DataRow("net8.0", "net8.0", "net8.0", ".NETCore", "8.0")]
         public async System.Threading.Tasks.Task CanExportDll(string toolFramework, string ikvmFramework, string targetFramework, string targetFrameworkIdentifier, string targetFrameworkVersion)
         {
-            if (toolFramework == "net472" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
-                return;
-            if (targetFrameworkIdentifier == ".NETFramework" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
-                return;
-
             var ikvmLibs = Path.Combine(TESTBASE, "lib", ikvmFramework);
             var refsPath = DotNetSdkUtil.GetPathToReferenceAssemblies(targetFramework, targetFrameworkIdentifier, targetFrameworkVersion) ;
 
@@ -48,26 +43,26 @@ namespace IKVM.Tools.Tests.Runner.Exporter
             var d = Path.GetDirectoryName(p);
             Directory.CreateDirectory(d);
 
-            var rid = "";
+            var toolRid = "";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture == Architecture.X64)
-                rid = "win-x64";
+                toolRid = "win-x64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                rid = "win-arm64";
+                toolRid = "win-arm64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.X64)
-                rid = "linux-x64";
+                toolRid = "linux-x64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.Arm)
-                rid = "linux-arm";
+                toolRid = "linux-arm";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                rid = "linux-arm64";
+                toolRid = "linux-arm64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.X64)
-                rid = "osx-x64";
+                toolRid = "osx-x64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                rid = "osx-arm64";
-            if (string.IsNullOrEmpty(rid))
+                toolRid = "osx-arm64";
+            if (string.IsNullOrEmpty(toolRid))
                 return;
 
             var e = new List<IkvmToolDiagnosticEvent>();
-            var l = new IkvmExporterLauncher(Path.Combine(Path.GetDirectoryName(typeof(IkvmExporterLauncherTests).Assembly.Location), "ikvmstub", toolFramework, rid), new IkvmToolDelegateDiagnosticListener(evt => { e.Add(evt); TestContext.WriteLine(evt.Message, evt.Args); }));
+            var l = new IkvmExporterLauncher(Path.Combine(Path.GetDirectoryName(typeof(IkvmExporterLauncherTests).Assembly.Location), "ikvmstub", toolFramework, toolRid), new IkvmToolDelegateDiagnosticListener(evt => { e.Add(evt); TestContext.WriteLine(evt.Message, evt.Args); }));
             var o = new IkvmExporterOptions()
             {
                 NoStdLib = true,

--- a/src/IKVM.Tools.Tests/Runner/Importer/IkvmImporterLauncherTests.cs
+++ b/src/IKVM.Tools.Tests/Runner/Importer/IkvmImporterLauncherTests.cs
@@ -35,11 +35,6 @@ namespace IKVM.Tools.Tests.Runner.Importer
         [DataRow("net8.0", "net8.0", "net8.0", ".NETCore", "8.0")]
         public async System.Threading.Tasks.Task CanImportJar(string toolFramework, string ikvmFramework, string targetFrameworkMoniker, string targetFrameworkIdentifier, string targetFrameworkVersion)
         {
-            if (toolFramework == "net472" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
-                return;
-            if (targetFrameworkIdentifier == ".NETFramework" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
-                return;
-
             var ikvmLibs = Path.Combine(TESTBASE, "lib", ikvmFramework);
             var refsPath = DotNetSdkUtil.GetPathToReferenceAssemblies(targetFrameworkMoniker, targetFrameworkIdentifier, targetFrameworkVersion);
 
@@ -47,26 +42,26 @@ namespace IKVM.Tools.Tests.Runner.Importer
             var d = Path.GetDirectoryName(p);
             Directory.CreateDirectory(d);
 
-            var rid = "";
+            var toolRid = "";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture == Architecture.X64)
-                rid = "win-x64";
+                toolRid = "win-x64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                rid = "win-arm64";
+                toolRid = "win-arm64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.X64)
-                rid = "linux-x64";
+                toolRid = "linux-x64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.Arm)
-                rid = "linux-arm";
+                toolRid = "linux-arm";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                rid = "linux-arm64";
+                toolRid = "linux-arm64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.X64)
-                rid = "osx-x64";
+                toolRid = "osx-x64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                rid = "osx-arm64";
-            if (string.IsNullOrEmpty(rid))
+                toolRid = "osx-arm64";
+            if (string.IsNullOrEmpty(toolRid))
                 return;
 
             var e = new List<IkvmToolDiagnosticEvent>();
-            var l = new IkvmImporterLauncher(Path.Combine(Path.GetDirectoryName(typeof(IkvmImporterLauncherTests).Assembly.Location), "ikvmc", toolFramework, rid), new IkvmToolDelegateDiagnosticListener(evt => { e.Add(evt); TestContext.WriteLine(evt.Message, evt.Args); }));
+            var l = new IkvmImporterLauncher(Path.Combine(Path.GetDirectoryName(typeof(IkvmImporterLauncherTests).Assembly.Location), "ikvmc", toolFramework, toolRid), new IkvmToolDelegateDiagnosticListener(evt => { e.Add(evt); TestContext.WriteLine(evt.Message, evt.Args); }));
             var o = new IkvmImporterOptions()
             {
                 Runtime = Path.Combine(ikvmLibs, "IKVM.Runtime.dll"),


### PR DESCRIPTION
Since the tools run properly on Mono, and we use this for our internal builds, I think it makes sense to reintroduce them for linux-x64, osx-x64 and osx-arm64. In cases where we're targeting net472 tools, but running on a Linux OS, we use Mono to execute ikvmc.exe and ikvmstub.exe.

This simply relies on 'mono' being present on the path, and the proper libraries installed in Mono. For Debian based OSs, this means you'll need mono-devel.