### PR TITLE
Fix Interface Type Merge in Data Flow Analysis

### DIFF
--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -132,11 +132,11 @@ jobs:
         version: latest
         locked: false
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1
+      uses: gittools/actions/gitversion/setup@v3
       with:
         versionSpec: 5.x
     - name: Execute GitVersion
-      uses: gittools/actions/gitversion/execute@v1
+      uses: gittools/actions/gitversion/execute@v3
       with:
         useConfigFile: true
         configFilePath: GitVersion.yml
@@ -679,12 +679,12 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1
+      uses: gittools/actions/gitversion/setup@v3
       with:
         versionSpec: 5.x
     - name: Execute GitVersion
       id: GitVersion
-      uses: gittools/actions/gitversion/execute@v1
+      uses: gittools/actions/gitversion/execute@v3
       with:
         useConfigFile: true
     - name: Download NuGet Packages

--- a/src/IKVM.Runtime/ExceptionTableEntryComparer.cs
+++ b/src/IKVM.Runtime/ExceptionTableEntryComparer.cs
@@ -28,34 +28,35 @@ using ExceptionTableEntry = IKVM.Runtime.ClassFile.Method.ExceptionTableEntry;
 namespace IKVM.Runtime
 {
 
-    sealed class ExceptionSorter : IComparer<ExceptionTableEntry>
+    /// <summary>
+    /// Implements the <see cref="IComparer{T}"/> interface for <see cref="ExceptionTableEntry"/>.
+    /// </summary>
+    sealed class ExceptionTableEntryComparer : IComparer<ExceptionTableEntry>
     {
 
+        /// <inheritdoc />
         public int Compare(ExceptionTableEntry e1, ExceptionTableEntry e2)
         {
             if (e1.startIndex < e2.startIndex)
-            {
                 return -1;
-            }
+
             if (e1.startIndex == e2.startIndex)
             {
                 if (e1.endIndex == e2.endIndex)
                 {
                     if (e1.ordinal > e2.ordinal)
-                    {
                         return -1;
-                    }
+
                     if (e1.ordinal == e2.ordinal)
-                    {
                         return 0;
-                    }
+
                     return 1;
                 }
+
                 if (e1.endIndex > e2.endIndex)
-                {
                     return -1;
-                }
             }
+
             return 1;
         }
 

--- a/src/IKVM.Runtime/InstructionState.cs
+++ b/src/IKVM.Runtime/InstructionState.cs
@@ -24,10 +24,6 @@
 using System;
 using System.Collections.Generic;
 
-#if IMPORTER
-using IKVM.Tools.Importer;
-#endif
-
 namespace IKVM.Runtime
 {
 
@@ -80,21 +76,9 @@ namespace IKVM.Runtime
                 data[count++] = store;
             }
 
-            internal int this[int index]
-            {
-                get
-                {
-                    return data[index];
-                }
-            }
+            internal int this[int index] => data[index];
 
-            internal int Count
-            {
-                get
-                {
-                    return count;
-                }
-            }
+            internal int Count => count;
 
             internal static void MarkShared(LocalStoreSites[] localStoreSites)
             {
@@ -112,131 +96,168 @@ namespace IKVM.Runtime
             All = Stack | Locals
         }
 
-        readonly RuntimeContext context;
-        RuntimeJavaType[] stack;
-        int stackSize;
-        int stackEnd;
-        RuntimeJavaType[] locals;
-        bool unitializedThis;
-        internal bool changed = true;
+        readonly RuntimeContext _context;
+        RuntimeJavaType[] _stack;
+        int _stackLen;
+        int _stackEnd;
+        RuntimeJavaType[] _locals;
+        bool _uninitializedThis;
+        internal bool _changed = true;
 
-        private ShareFlags flags;
+        ShareFlags _flags;
 
-        private InstructionState(RuntimeContext context, RuntimeJavaType[] stack, int stackSize, int stackEnd, RuntimeJavaType[] locals, bool unitializedThis)
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="stack"></param>
+        /// <param name="stackLen"></param>
+        /// <param name="stackEnd"></param>
+        /// <param name="locals"></param>
+        /// <param name="uninitializedThis"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        InstructionState(RuntimeContext context, RuntimeJavaType[] stack, int stackLen, int stackEnd, RuntimeJavaType[] locals, bool uninitializedThis)
         {
-            this.context = context ?? throw new ArgumentNullException(nameof(context));
-            this.flags = ShareFlags.All;
-            this.stack = stack;
-            this.stackSize = stackSize;
-            this.stackEnd = stackEnd;
-            this.locals = locals;
-            this.unitializedThis = unitializedThis;
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _flags = ShareFlags.All;
+            _stack = stack;
+            _stackLen = stackLen;
+            _stackEnd = stackEnd;
+            _locals = locals;
+            _uninitializedThis = uninitializedThis;
         }
 
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="maxLocals"></param>
+        /// <param name="maxStack"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         internal InstructionState(RuntimeContext context, int maxLocals, int maxStack)
         {
-            this.context = context ?? throw new ArgumentNullException(nameof(context));
-            this.flags = ShareFlags.None;
-            this.stack = new RuntimeJavaType[maxStack];
-            this.stackEnd = maxStack;
-            this.locals = new RuntimeJavaType[maxLocals];
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _flags = ShareFlags.None;
+            _stack = new RuntimeJavaType[maxStack];
+            _stackEnd = maxStack;
+            _locals = new RuntimeJavaType[maxLocals];
         }
 
+        /// <summary>
+        /// Creates a copy of this instance.
+        /// </summary>
+        /// <returns></returns>
         internal InstructionState Copy()
         {
-            return new InstructionState(context, stack, stackSize, stackEnd, locals, unitializedThis);
+            return new InstructionState(_context, _stack, _stackLen, _stackEnd, _locals, _uninitializedThis);
         }
 
+        /// <summary>
+        /// Copies this instruction state to the specified instruction state.
+        /// </summary>
+        /// <param name="target"></param>
         internal void CopyTo(InstructionState target)
         {
-            target.flags = ShareFlags.All;
-            target.stack = stack;
-            target.stackSize = stackSize;
-            target.stackEnd = stackEnd;
-            target.locals = locals;
-            target.unitializedThis = unitializedThis;
-            target.changed = true;
+            target._flags = ShareFlags.All;
+            target._stack = _stack;
+            target._stackLen = _stackLen;
+            target._stackEnd = _stackEnd;
+            target._locals = _locals;
+            target._uninitializedThis = _uninitializedThis;
+            target._changed = true;
         }
 
+        /// <summary>
+        /// Creates a new instance with the same local variables.
+        /// </summary>
+        /// <returns></returns>
         internal InstructionState CopyLocals()
         {
-            InstructionState copy = new InstructionState(context, new RuntimeJavaType[stack.Length], 0, stack.Length, locals, unitializedThis);
-            copy.flags &= ~ShareFlags.Stack;
+            var copy = new InstructionState(_context, new RuntimeJavaType[_stack.Length], 0, _stack.Length, _locals, _uninitializedThis);
+            copy._flags &= ~ShareFlags.Stack;
             return copy;
         }
 
+        /// <summary>
+        /// Creates a new state which is the merged combination of the two specified states.
+        /// </summary>
+        /// <param name="s1"></param>
+        /// <param name="s2"></param>
+        /// <returns></returns>
+        /// <exception cref="VerifyError"></exception>
         public static InstructionState operator +(InstructionState s1, InstructionState s2)
         {
             if (s1 == null)
                 return s2.Copy();
 
-            if (s1.stackSize != s2.stackSize || s1.stackEnd != s2.stackEnd)
-                throw new VerifyError($"Inconsistent stack height: {s1.stackSize + s1.stack.Length - s1.stackEnd} != {s2.stackSize + s2.stack.Length - s2.stackEnd}");
+            if (s1._stackLen != s2._stackLen || s1._stackEnd != s2._stackEnd)
+                throw new VerifyError($"Inconsistent stack height: {s1._stackLen + s1._stack.Length - s1._stackEnd} != {s2._stackLen + s2._stack.Length - s2._stackEnd}");
 
             var s = s1.Copy();
-            s.changed = s1.changed;
-            for (int i = 0; i < s.stackSize; i++)
+            s._changed = s1._changed;
+
+            for (int i = 0; i < s._stackLen; i++)
             {
-                var type = s.stack[i];
-                var type2 = s2.stack[i];
-                if (type == type2)
+                var type1 = s._stack[i];
+                var type2 = s2._stack[i];
+                if (type1 == type2)
                 {
                     // perfect match, nothing to do
                 }
-                else if ((type == s1.context.VerifierJavaTypeFactory.ExtendedDouble && type2 == s1.context.PrimitiveJavaTypeFactory.DOUBLE) || (type2 == s1.context.VerifierJavaTypeFactory.ExtendedDouble && type == s1.context.PrimitiveJavaTypeFactory.DOUBLE))
+                else if ((type1 == s1._context.VerifierJavaTypeFactory.ExtendedDouble && type2 == s1._context.PrimitiveJavaTypeFactory.DOUBLE) || (type2 == s1._context.VerifierJavaTypeFactory.ExtendedDouble && type1 == s1._context.PrimitiveJavaTypeFactory.DOUBLE))
                 {
-                    if (type != s1.context.VerifierJavaTypeFactory.ExtendedDouble)
+                    if (type1 != s1._context.VerifierJavaTypeFactory.ExtendedDouble)
                     {
                         s.StackCopyOnWrite();
-                        s.stack[i] = s1.context.VerifierJavaTypeFactory.ExtendedDouble;
-                        s.changed = true;
+                        s._stack[i] = s1._context.VerifierJavaTypeFactory.ExtendedDouble;
+                        s._changed = true;
                     }
                 }
-                else if ((type == s1.context.VerifierJavaTypeFactory.ExtendedFloat && type2 == s1.context.PrimitiveJavaTypeFactory.FLOAT) || (type2 == s1.context.VerifierJavaTypeFactory.ExtendedFloat && type == s1.context.PrimitiveJavaTypeFactory.FLOAT))
+                else if ((type1 == s1._context.VerifierJavaTypeFactory.ExtendedFloat && type2 == s1._context.PrimitiveJavaTypeFactory.FLOAT) || (type2 == s1._context.VerifierJavaTypeFactory.ExtendedFloat && type1 == s1._context.PrimitiveJavaTypeFactory.FLOAT))
                 {
-                    if (type != s1.context.VerifierJavaTypeFactory.ExtendedFloat)
+                    if (type1 != s1._context.VerifierJavaTypeFactory.ExtendedFloat)
                     {
                         s.StackCopyOnWrite();
-                        s.stack[i] = s1.context.VerifierJavaTypeFactory.ExtendedFloat;
-                        s.changed = true;
+                        s._stack[i] = s1._context.VerifierJavaTypeFactory.ExtendedFloat;
+                        s._changed = true;
                     }
                 }
-                else if (!type.IsPrimitive)
+                else if (!type1.IsPrimitive)
                 {
-                    var baseType = FindCommonBaseType(s1.context, type, type2);
-                    if (baseType == s1.context.VerifierJavaTypeFactory.Invalid)
-                        throw new VerifyError(string.Format("cannot merge {0} and {1}", type.Name, type2.Name));
+                    var baseType = FindCommonBaseType(s1._context, type1, type2);
+                    if (baseType == s1._context.VerifierJavaTypeFactory.Invalid)
+                        throw new VerifyError(string.Format("cannot merge {0} and {1}", type1.Name, type2.Name));
 
-                    if (type != baseType)
+                    if (type1 != baseType)
                     {
                         s.StackCopyOnWrite();
-                        s.stack[i] = baseType;
-                        s.changed = true;
+                        s._stack[i] = baseType;
+                        s._changed = true;
                     }
                 }
                 else
                 {
-                    throw new VerifyError(string.Format("cannot merge {0} and {1}", type.Name, type2.Name));
+                    throw new VerifyError(string.Format("cannot merge {0} and {1}", type1.Name, type2.Name));
                 }
             }
 
-            for (int i = 0; i < s.locals.Length; i++)
+            for (int i = 0; i < s._locals.Length; i++)
             {
-                var type = s.locals[i];
-                var type2 = s2.locals[i];
-                var baseType = FindCommonBaseType(s1.context, type, type2);
+                var type = s._locals[i];
+                var type2 = s2._locals[i];
+                var baseType = FindCommonBaseType(s1._context, type, type2);
                 if (type != baseType)
                 {
                     s.LocalsCopyOnWrite();
-                    s.locals[i] = baseType;
-                    s.changed = true;
+                    s._locals[i] = baseType;
+                    s._changed = true;
                 }
             }
 
-            if (!s.unitializedThis && s2.unitializedThis)
+            if (!s._uninitializedThis && s2._uninitializedThis)
             {
-                s.unitializedThis = true;
-                s.changed = true;
+                s._uninitializedThis = true;
+                s._changed = true;
             }
 
             return s;
@@ -244,12 +265,12 @@ namespace IKVM.Runtime
 
         internal void SetUnitializedThis(bool state)
         {
-            unitializedThis = state;
+            _uninitializedThis = state;
         }
 
         internal void CheckUninitializedThis()
         {
-            if (unitializedThis)
+            if (_uninitializedThis)
                 throw new VerifyError("Base class constructor wasn't called");
         }
 
@@ -402,10 +423,10 @@ namespace IKVM.Runtime
             try
             {
                 LocalsCopyOnWrite();
-                if (index > 0 && locals[index - 1] != context.VerifierJavaTypeFactory.Invalid && locals[index - 1].IsWidePrimitive)
-                    locals[index - 1] = context.VerifierJavaTypeFactory.Invalid;
+                if (index > 0 && _locals[index - 1] != _context.VerifierJavaTypeFactory.Invalid && _locals[index - 1].IsWidePrimitive)
+                    _locals[index - 1] = _context.VerifierJavaTypeFactory.Invalid;
 
-                locals[index] = type;
+                _locals[index] = type;
             }
             catch (IndexOutOfRangeException)
             {
@@ -418,11 +439,11 @@ namespace IKVM.Runtime
             try
             {
                 LocalsCopyOnWrite();
-                if (index > 0 && locals[index - 1] != context.VerifierJavaTypeFactory.Invalid && locals[index - 1].IsWidePrimitive)
-                    locals[index - 1] = context.VerifierJavaTypeFactory.Invalid;
+                if (index > 0 && _locals[index - 1] != _context.VerifierJavaTypeFactory.Invalid && _locals[index - 1].IsWidePrimitive)
+                    _locals[index - 1] = _context.VerifierJavaTypeFactory.Invalid;
 
-                locals[index] = type;
-                locals[index + 1] = context.VerifierJavaTypeFactory.Invalid;
+                _locals[index] = type;
+                _locals[index + 1] = _context.VerifierJavaTypeFactory.Invalid;
             }
             catch (IndexOutOfRangeException)
             {
@@ -432,53 +453,53 @@ namespace IKVM.Runtime
 
         internal void GetLocalInt(int index)
         {
-            if (GetLocalType(index) != context.PrimitiveJavaTypeFactory.INT)
+            if (GetLocalType(index) != _context.PrimitiveJavaTypeFactory.INT)
                 throw new VerifyError("Invalid local type");
         }
 
         internal void SetLocalInt(int index, int instructionIndex)
         {
-            SetLocal1(index, context.PrimitiveJavaTypeFactory.INT);
+            SetLocal1(index, _context.PrimitiveJavaTypeFactory.INT);
         }
 
         internal void GetLocalLong(int index)
         {
-            if (GetLocalType(index) != context.PrimitiveJavaTypeFactory.LONG)
+            if (GetLocalType(index) != _context.PrimitiveJavaTypeFactory.LONG)
                 throw new VerifyError("incorrect local type, not long");
         }
 
         internal void SetLocalLong(int index, int instructionIndex)
         {
-            SetLocal2(index, context.PrimitiveJavaTypeFactory.LONG);
+            SetLocal2(index, _context.PrimitiveJavaTypeFactory.LONG);
         }
 
         internal void GetLocalFloat(int index)
         {
-            if (GetLocalType(index) != context.PrimitiveJavaTypeFactory.FLOAT)
+            if (GetLocalType(index) != _context.PrimitiveJavaTypeFactory.FLOAT)
                 throw new VerifyError("incorrect local type, not float");
         }
 
         internal void SetLocalFloat(int index, int instructionIndex)
         {
-            SetLocal1(index, context.PrimitiveJavaTypeFactory.FLOAT);
+            SetLocal1(index, _context.PrimitiveJavaTypeFactory.FLOAT);
         }
 
         internal void GetLocalDouble(int index)
         {
-            if (GetLocalType(index) != context.PrimitiveJavaTypeFactory.DOUBLE)
+            if (GetLocalType(index) != _context.PrimitiveJavaTypeFactory.DOUBLE)
                 throw new VerifyError("incorrect local type, not double");
         }
 
         internal void SetLocalDouble(int index, int instructionIndex)
         {
-            SetLocal2(index, context.PrimitiveJavaTypeFactory.DOUBLE);
+            SetLocal2(index, _context.PrimitiveJavaTypeFactory.DOUBLE);
         }
 
         internal RuntimeJavaType GetLocalType(int index)
         {
             try
             {
-                return locals[index];
+                return _locals[index];
             }
             catch (IndexOutOfRangeException)
             {
@@ -491,7 +512,7 @@ namespace IKVM.Runtime
         // and we don't need to record the fact that we're reading the local.
         internal RuntimeJavaType GetLocalTypeEx(int index)
         {
-            return locals[index];
+            return _locals[index];
         }
 
         internal void SetLocalType(int index, RuntimeJavaType type, int instructionIndex)
@@ -505,39 +526,39 @@ namespace IKVM.Runtime
         internal void PushType(RuntimeJavaType type)
         {
             if (type.IsIntOnStackPrimitive)
-                type = context.PrimitiveJavaTypeFactory.INT;
+                type = _context.PrimitiveJavaTypeFactory.INT;
 
             PushHelper(type);
         }
 
         internal void PushInt()
         {
-            PushHelper(context.PrimitiveJavaTypeFactory.INT);
+            PushHelper(_context.PrimitiveJavaTypeFactory.INT);
         }
 
         internal void PushLong()
         {
-            PushHelper(context.PrimitiveJavaTypeFactory.LONG);
+            PushHelper(_context.PrimitiveJavaTypeFactory.LONG);
         }
 
         internal void PushFloat()
         {
-            PushHelper(context.PrimitiveJavaTypeFactory.FLOAT);
+            PushHelper(_context.PrimitiveJavaTypeFactory.FLOAT);
         }
 
         internal void PushExtendedFloat()
         {
-            PushHelper(context.VerifierJavaTypeFactory.ExtendedFloat);
+            PushHelper(_context.VerifierJavaTypeFactory.ExtendedFloat);
         }
 
         internal void PushDouble()
         {
-            PushHelper(context.PrimitiveJavaTypeFactory.DOUBLE);
+            PushHelper(_context.PrimitiveJavaTypeFactory.DOUBLE);
         }
 
         internal void PushExtendedDouble()
         {
-            PushHelper(context.VerifierJavaTypeFactory.ExtendedDouble);
+            PushHelper(_context.VerifierJavaTypeFactory.ExtendedDouble);
         }
 
         internal void PopInt()
@@ -555,7 +576,7 @@ namespace IKVM.Runtime
         {
             var tw = PopAnyType();
             PopFloatImpl(tw);
-            return tw == context.VerifierJavaTypeFactory.ExtendedFloat;
+            return tw == _context.VerifierJavaTypeFactory.ExtendedFloat;
         }
 
         internal static void PopFloatImpl(RuntimeJavaType tw)
@@ -568,7 +589,7 @@ namespace IKVM.Runtime
         {
             var tw = PopAnyType();
             PopDoubleImpl(tw);
-            return tw == context.VerifierJavaTypeFactory.ExtendedDouble;
+            return tw == _context.VerifierJavaTypeFactory.ExtendedDouble;
         }
 
         internal static void PopDoubleImpl(RuntimeJavaType tw)
@@ -635,10 +656,10 @@ namespace IKVM.Runtime
 
         internal RuntimeJavaType PeekType()
         {
-            if (stackSize == 0)
+            if (_stackLen == 0)
                 throw new VerifyError("Unable to pop operand off an empty stack");
 
-            return stack[stackSize - 1];
+            return _stack[_stackLen - 1];
         }
 
         internal void MultiPopAnyType(int count)
@@ -649,17 +670,17 @@ namespace IKVM.Runtime
 
         internal RuntimeJavaType PopFaultBlockException()
         {
-            return stack[--stackSize];
+            return _stack[--_stackLen];
         }
 
         internal RuntimeJavaType PopAnyType()
         {
-            if (stackSize == 0)
+            if (_stackLen == 0)
                 throw new VerifyError("Unable to pop operand off an empty stack");
 
-            var type = stack[--stackSize];
-            if (type.IsWidePrimitive || type == context.VerifierJavaTypeFactory.ExtendedDouble)
-                stackEnd++;
+            var type = _stack[--_stackLen];
+            if (type.IsWidePrimitive || type == _context.VerifierJavaTypeFactory.ExtendedDouble)
+                _stackEnd++;
 
             if (RuntimeVerifierJavaType.IsThis(type))
                 type = ((RuntimeVerifierJavaType)type).UnderlyingType;
@@ -667,7 +688,7 @@ namespace IKVM.Runtime
             if (RuntimeVerifierJavaType.IsFaultBlockException(type))
             {
                 RuntimeVerifierJavaType.ClearFaultBlockException(type);
-                type = context.JavaBase.TypeOfjavaLangThrowable;
+                type = _context.JavaBase.TypeOfjavaLangThrowable;
             }
 
             return type;
@@ -752,116 +773,96 @@ namespace IKVM.Runtime
 
         internal int GetStackHeight()
         {
-            return stackSize;
+            return _stackLen;
         }
 
         internal RuntimeJavaType GetStackSlot(int pos)
         {
-            var tw = stack[stackSize - 1 - pos];
-            if (tw == context.VerifierJavaTypeFactory.ExtendedDouble)
-                tw = context.PrimitiveJavaTypeFactory.DOUBLE;
-            else if (tw == context.VerifierJavaTypeFactory.ExtendedFloat)
-                tw = context.PrimitiveJavaTypeFactory.FLOAT;
+            var tw = _stack[_stackLen - 1 - pos];
+            if (tw == _context.VerifierJavaTypeFactory.ExtendedDouble)
+                tw = _context.PrimitiveJavaTypeFactory.DOUBLE;
+            else if (tw == _context.VerifierJavaTypeFactory.ExtendedFloat)
+                tw = _context.PrimitiveJavaTypeFactory.FLOAT;
 
             return tw;
         }
 
         internal RuntimeJavaType GetStackSlotEx(int pos)
         {
-            return stack[stackSize - 1 - pos];
+            return _stack[_stackLen - 1 - pos];
         }
 
         internal RuntimeJavaType GetStackByIndex(int index)
         {
-            return stack[index];
+            return _stack[index];
         }
 
         void PushHelper(RuntimeJavaType type)
         {
-            if (type.IsWidePrimitive || type == context.VerifierJavaTypeFactory.ExtendedDouble)
-                stackEnd--;
+            if (type.IsWidePrimitive || type == _context.VerifierJavaTypeFactory.ExtendedDouble)
+                _stackEnd--;
 
-            if (stackSize >= stackEnd)
+            if (_stackLen >= _stackEnd)
                 throw new VerifyError("Stack overflow");
 
             StackCopyOnWrite();
-            stack[stackSize++] = type;
+            _stack[_stackLen++] = type;
         }
 
         internal void MarkInitialized(RuntimeJavaType type, RuntimeJavaType initType, int instructionIndex)
         {
             System.Diagnostics.Debug.Assert(type != null && initType != null);
 
-            for (int i = 0; i < locals.Length; i++)
+            for (int i = 0; i < _locals.Length; i++)
             {
-                if (locals[i] == type)
+                if (_locals[i] == type)
                 {
                     LocalsCopyOnWrite();
-                    locals[i] = initType;
+                    _locals[i] = initType;
                 }
             }
 
-            for (int i = 0; i < stackSize; i++)
+            for (int i = 0; i < _stackLen; i++)
             {
-                if (stack[i] == type)
+                if (_stack[i] == type)
                 {
                     StackCopyOnWrite();
-                    stack[i] = initType;
+                    _stack[i] = initType;
                 }
             }
         }
 
+        /// <summary>
+        /// Copies the stack for future modification.
+        /// </summary>
         void StackCopyOnWrite()
         {
-            if ((flags & ShareFlags.Stack) != 0)
+            if ((_flags & ShareFlags.Stack) != 0)
             {
-                flags &= ~ShareFlags.Stack;
-                stack = (RuntimeJavaType[])stack.Clone();
+                _flags &= ~ShareFlags.Stack;
+                _stack = (RuntimeJavaType[])_stack.Clone();
             }
         }
 
+        /// <summary>
+        /// Copies the locals for future modification.
+        /// </summary>
         void LocalsCopyOnWrite()
         {
-            if ((flags & ShareFlags.Locals) != 0)
+            if ((_flags & ShareFlags.Locals) != 0)
             {
-                flags &= ~ShareFlags.Locals;
-                locals = (RuntimeJavaType[])locals.Clone();
+                _flags &= ~ShareFlags.Locals;
+                _locals = (RuntimeJavaType[])_locals.Clone();
             }
-        }
-
-        internal void DumpLocals()
-        {
-            Console.Write("// ");
-            string sep = "";
-            for (int i = 0; i < locals.Length; i++)
-            {
-                Console.Write(sep);
-                Console.Write(locals[i]);
-                sep = ", ";
-            }
-            Console.WriteLine();
-        }
-
-        internal void DumpStack()
-        {
-            Console.Write("// ");
-            string sep = "";
-            for (int i = 0; i < stackSize; i++)
-            {
-                Console.Write(sep);
-                Console.Write(stack[i]);
-                sep = ", ";
-            }
-            Console.WriteLine();
         }
 
         internal void ClearFaultBlockException()
         {
-            if (RuntimeVerifierJavaType.IsFaultBlockException(stack[0]))
+            if (RuntimeVerifierJavaType.IsFaultBlockException(_stack[0]))
             {
                 StackCopyOnWrite();
-                changed = true;
-                stack[0] = context.JavaBase.TypeOfjavaLangThrowable;
+                _changed = true;
+                _stack[0] = _context.JavaBase.TypeOfjavaLangThrowable;
             }
         }
 

--- a/src/IKVM.Runtime/InstructionState.cs
+++ b/src/IKVM.Runtime/InstructionState.cs
@@ -285,10 +285,6 @@ namespace IKVM.Runtime
             if (type1 == context.JavaBase.TypeOfJavaLangObject || type2 == context.JavaBase.TypeOfJavaLangObject)
                 return context.JavaBase.TypeOfJavaLangObject;
 
-            // verifier invalid
-            if (type1 == context.VerifierJavaTypeFactory.Invalid || type2 == context.VerifierJavaTypeFactory.Invalid)
-                return context.VerifierJavaTypeFactory.Invalid;
-
             // first type is null, return second
             if (type1 == context.VerifierJavaTypeFactory.Null)
                 return type2;
@@ -296,6 +292,10 @@ namespace IKVM.Runtime
             // second type is null, return first
             if (type2 == context.VerifierJavaTypeFactory.Null)
                 return type1;
+
+            // verifier invalid
+            if (type1 == context.VerifierJavaTypeFactory.Invalid || type2 == context.VerifierJavaTypeFactory.Invalid)
+                return context.VerifierJavaTypeFactory.Invalid;
 
             if (RuntimeVerifierJavaType.IsFaultBlockException(type1))
             {

--- a/src/IKVM.Runtime/InstructionState.cs
+++ b/src/IKVM.Runtime/InstructionState.cs
@@ -375,6 +375,14 @@ namespace IKVM.Runtime
                 return context.JavaBase.TypeOfJavaLangObject;
             }
 
+            // t1 is an interface and is implemented by t2, common base type is t1
+            if (t1.IsInterface && t2.ImplementsInterface(t1))
+                return t1;
+
+            // t2 is an interface and is implemented by t1, common base type is t2
+            if (t2.IsInterface && t1.ImplementsInterface(t2))
+                return t2;
+
             var st1 = new Stack<RuntimeJavaType>();
             var st2 = new Stack<RuntimeJavaType>();
 

--- a/src/IKVM.Runtime/InstructionState.cs
+++ b/src/IKVM.Runtime/InstructionState.cs
@@ -23,6 +23,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace IKVM.Runtime
 {
@@ -357,73 +358,55 @@ namespace IKVM.Runtime
             return FindCommonBaseTypeHelper(context, type1, type2);
         }
 
-        static RuntimeJavaType FindCommonBaseTypeHelper(RuntimeContext context, RuntimeJavaType t1, RuntimeJavaType t2)
+        static RuntimeJavaType FindCommonBaseTypeHelper(RuntimeContext context, RuntimeJavaType type1, RuntimeJavaType type2)
         {
-            if (t1 == t2)
-                return t1;
+            if (type1 == type2)
+                return type1;
 
-            if (t1.IsInterface || t2.IsInterface)
-            {
-                // NOTE according to a paper by Alessandro Coglio & Allen Goldberg titled
-                // "Type Safety in the JVM: Some Problems in Java 2 SDK 1.2 and Proposed Solutions"
-                // the common base of two interfaces is java.lang.Object, and there is special
-                // treatment for java.lang.Object types that allow it to be assigned to any interface
-                // type, the JVM's typesafety then depends on the invokeinterface instruction to make
-                // sure that the reference actually implements the interface.
-                // NOTE the ECMA CLI spec also specifies this interface merging algorithm, so we can't
-                // really do anything more clever than this.
+            // NOTE according to a paper by Alessandro Coglio & Allen Goldberg titled
+            // "Type Safety in the JVM: Some Problems in Java 2 SDK 1.2 and Proposed Solutions"
+            // the common base of two interfaces is java.lang.Object, and there is special
+            // treatment for java.lang.Object types that allow it to be assigned to any interface
+            // type, the JVM's typesafety then depends on the invokeinterface instruction to make
+            // sure that the reference actually implements the interface.
+            // NOTE the ECMA CLI spec also specifies this interface merging algorithm, so we can't
+            // really do anything more clever than this.
+            if (type1.IsInterface && type2.IsInterface)
                 return context.JavaBase.TypeOfJavaLangObject;
-            }
 
             // t1 is an interface and is implemented by t2, common base type is t1
-            if (t1.IsInterface && t2.ImplementsInterface(t1))
-                return t1;
+            if (type1.IsInterface)
+                return type2.ImplementsInterface(type1) ? type1 : context.JavaBase.TypeOfJavaLangObject;
 
             // t2 is an interface and is implemented by t1, common base type is t2
-            if (t2.IsInterface && t1.ImplementsInterface(t2))
-                return t2;
+            if (type2.IsInterface)
+                return type1.ImplementsInterface(type2) ? type2 : context.JavaBase.TypeOfJavaLangObject;
 
             var st1 = new Stack<RuntimeJavaType>();
+            while (type1 != null)
+            {
+                st1.Push(type1);
+                type1 = type1.BaseTypeWrapper;
+            }
+
             var st2 = new Stack<RuntimeJavaType>();
-
-            while (t1 != null)
+            while (type2 != null)
             {
-                st1.Push(t1);
-                t1 = t1.BaseTypeWrapper;
+                st2.Push(type2);
+                type2 = type2.BaseTypeWrapper;
             }
 
-            while (t2 != null)
-            {
-                st2.Push(t2);
-                t2 = t2.BaseTypeWrapper;
-            }
-
-            if (HasMissingBaseType(context, st1) || HasMissingBaseType(context, st2))
-                return context.VerifierJavaTypeFactory.Unloadable;
-
+            // pop each item off of the stacks until they do not match
             var type = context.JavaBase.TypeOfJavaLangObject;
             for (; ; )
             {
-                t1 = st1.Count > 0 ? st1.Pop() : null;
-                t2 = st2.Count > 0 ? st2.Pop() : null;
-                if (t1 != t2)
+                type1 = st1.Count > 0 ? st1.Pop() : null;
+                type2 = st2.Count > 0 ? st2.Pop() : null;
+                if (type1 != type2)
                     return type;
 
-                type = t1;
+                type = type1;
             }
-        }
-
-        static bool HasMissingBaseType(RuntimeContext context, Stack<RuntimeJavaType> st)
-        {
-#if IMPORTER
-            if (st.Pop().IsUnloadable)
-            {
-                // we have a missing type in base class hierarchy
-                context.StaticCompiler.IssueMissingTypeMessage(st.Pop().TypeAsBaseType.BaseType);
-                return true;
-            }
-#endif
-            return false;
         }
 
         void SetLocal1(int index, RuntimeJavaType type)

--- a/src/IKVM.Runtime/LocalVarInfo.cs
+++ b/src/IKVM.Runtime/LocalVarInfo.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 
 using InstructionFlags = IKVM.Runtime.ClassFile.Method.InstructionFlags;
-using ExceptionTableEntry = IKVM.Runtime.ClassFile.Method.ExceptionTableEntry;
 
 namespace IKVM.Runtime
 {
@@ -34,38 +33,45 @@ namespace IKVM.Runtime
     struct LocalVarInfo
     {
 
-        private readonly LocalVar[/*instructionIndex*/] localVars;
-        private readonly LocalVar[/*instructionIndex*/][/*localIndex*/] invokespecialLocalVars;
-        private readonly LocalVar[/*index*/] allLocalVars;
+        readonly LocalVar[/*instructionIndex*/] localVars;
+        readonly LocalVar[/*instructionIndex*/][/*localIndex*/] invokespecialLocalVars;
+        readonly LocalVar[/*index*/] allLocalVars;
 
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="ma"></param>
+        /// <param name="classFile"></param>
+        /// <param name="method"></param>
+        /// <param name="exceptions"></param>
+        /// <param name="mw"></param>
+        /// <param name="classLoader"></param>
         internal LocalVarInfo(CodeInfo ma, ClassFile classFile, ClassFile.Method method, UntangledExceptionTable exceptions, RuntimeJavaMethod mw, RuntimeClassLoader classLoader)
         {
-            Dictionary<int, string>[] localStoreReaders = FindLocalVariables(ma, mw, classFile, method);
+            var localStoreReaders = FindLocalVariables(ma, mw, classFile, method);
 
             // now that we've done the code flow analysis, we can do a liveness analysis on the local variables
-            ClassFile.Method.Instruction[] instructions = method.Instructions;
-            Dictionary<long, LocalVar> localByStoreSite = new Dictionary<long, LocalVar>();
-            List<LocalVar> locals = new List<LocalVar>();
+            var instructions = method.Instructions;
+            var localByStoreSite = new Dictionary<long, LocalVar>();
+            var locals = new List<LocalVar>();
+
             for (int i = 0; i < localStoreReaders.Length; i++)
-            {
                 if (localStoreReaders[i] != null)
-                {
                     VisitLocalLoads(classLoader.Context, ma, method, locals, localByStoreSite, localStoreReaders[i], i, classLoader.EmitSymbols);
-                }
-            }
-            Dictionary<LocalVar, LocalVar> forwarders = new Dictionary<LocalVar, LocalVar>();
+
+            var forwarders = new Dictionary<LocalVar, LocalVar>();
             if (classLoader.EmitSymbols)
             {
-                InstructionFlags[] flags = MethodAnalyzer.ComputePartialReachability(ma, method.Instructions, exceptions, 0, false);
+                var flags = MethodAnalyzer.ComputePartialReachability(ma, method.Instructions, exceptions, 0, false);
+
                 // if we're emitting debug info, we need to keep dead stores as well...
                 for (int i = 0; i < instructions.Length; i++)
                 {
-                    if ((flags[i] & InstructionFlags.Reachable) != 0
-                        && IsStoreLocal(instructions[i].NormalizedOpCode))
+                    if ((flags[i] & InstructionFlags.Reachable) != 0 && IsStoreLocal(instructions[i].NormalizedOpCode))
                     {
-                        if (!localByStoreSite.ContainsKey(MakeKey(i, instructions[i].NormalizedArg1)))
+                        if (localByStoreSite.ContainsKey(MakeKey(i, instructions[i].NormalizedArg1)) == false)
                         {
-                            LocalVar v = new LocalVar();
+                            var v = new LocalVar();
                             v.local = instructions[i].NormalizedArg1;
                             v.type = ma.GetStackTypeWrapper(i, 0);
                             FindLvtEntry(v, method, i);
@@ -74,6 +80,7 @@ namespace IKVM.Runtime
                         }
                     }
                 }
+
                 // to make the debugging experience better, we have to trust the
                 // LocalVariableTable (unless it's clearly bogus) and merge locals
                 // together that are the same according to the LVT
@@ -81,14 +88,15 @@ namespace IKVM.Runtime
                 {
                     for (int j = i + 1; j < locals.Count; j++)
                     {
-                        LocalVar v1 = (LocalVar)locals[i];
-                        LocalVar v2 = (LocalVar)locals[j];
+                        var v1 = locals[i];
+                        var v2 = locals[j];
+
                         if (v1.name != null && v1.name == v2.name && v1.start_pc == v2.start_pc && v1.end_pc == v2.end_pc)
                         {
                             // we can only merge if the resulting type is valid (this protects against incorrect
                             // LVT data, but is also needed for constructors, where the uninitialized this is a different
                             // type from the initialized this)
-                            RuntimeJavaType tw = InstructionState.FindCommonBaseType(classLoader.Context, v1.type, v2.type);
+                            var tw = InstructionState.FindCommonBaseType(classLoader.Context, v1.type, v2.type);
                             if (tw != classLoader.Context.VerifierJavaTypeFactory.Invalid)
                             {
                                 v1.isArg |= v2.isArg;
@@ -107,8 +115,9 @@ namespace IKVM.Runtime
                 {
                     for (int j = i + 1; j < locals.Count; j++)
                     {
-                        LocalVar v1 = (LocalVar)locals[i];
-                        LocalVar v2 = (LocalVar)locals[j];
+                        var v1 = locals[i];
+                        var v2 = locals[j];
+
                         // if the two locals are the same, we merge them, this is a small
                         // optimization, it should *not* be required for correctness.
                         if (v1.local == v2.local && v1.type == v2.type)
@@ -121,6 +130,7 @@ namespace IKVM.Runtime
                     }
                 }
             }
+
             invokespecialLocalVars = new LocalVar[instructions.Length][];
             localVars = new LocalVar[instructions.Length];
             for (int i = 0; i < localVars.Length; i++)
@@ -129,6 +139,7 @@ namespace IKVM.Runtime
                 if (localStoreReaders[i] != null)
                 {
                     Debug.Assert(IsLoadLocal(instructions[i].NormalizedOpCode));
+
                     // lame way to look up the local variable for a load
                     // (by indirecting through a corresponding store)
                     foreach (int store in localStoreReaders[i].Keys)
@@ -143,42 +154,39 @@ namespace IKVM.Runtime
                     {
                         invokespecialLocalVars[i] = new LocalVar[method.MaxLocals];
                         for (int j = 0; j < invokespecialLocalVars[i].Length; j++)
-                        {
                             localByStoreSite.TryGetValue(MakeKey(i, j), out invokespecialLocalVars[i][j]);
-                        }
                     }
                     else
                     {
                         localByStoreSite.TryGetValue(MakeKey(i, instructions[i].NormalizedArg1), out v);
                     }
                 }
+
                 if (v != null)
                 {
-                    LocalVar fwd;
-                    if (forwarders.TryGetValue(v, out fwd))
-                    {
+                    if (forwarders.TryGetValue(v, out var fwd))
                         v = fwd;
-                    }
+
                     localVars[i] = v;
                 }
             }
-            this.allLocalVars = locals.ToArray();
+
+            allLocalVars = locals.ToArray();
         }
 
-        private static void FindLvtEntry(LocalVar lv, ClassFile.Method method, int instructionIndex)
+        static void FindLvtEntry(LocalVar lv, ClassFile.Method method, int instructionIndex)
         {
-            ClassFile.Method.LocalVariableTableEntry[] lvt = method.LocalVariableTableAttribute;
+            var lvt = method.LocalVariableTableAttribute;
             if (lvt != null)
             {
-                int pc = method.Instructions[instructionIndex].PC;
-                int nextPC = method.Instructions[instructionIndex + 1].PC;
-                bool isStore = IsStoreLocal(method.Instructions[instructionIndex].NormalizedOpCode);
-                foreach (ClassFile.Method.LocalVariableTableEntry e in lvt)
+                var pc = method.Instructions[instructionIndex].PC;
+                var nextPC = method.Instructions[instructionIndex + 1].PC;
+                var isStore = IsStoreLocal(method.Instructions[instructionIndex].NormalizedOpCode);
+
+                foreach (var e in lvt)
                 {
                     // TODO validate the contents of the LVT entry
-                    if (e.index == lv.local &&
-                        (e.start_pc <= pc || (e.start_pc == nextPC && isStore)) &&
-                        e.start_pc + e.length > pc)
+                    if (e.index == lv.local && (e.start_pc <= pc || (e.start_pc == nextPC && isStore)) && e.start_pc + e.length > pc)
                     {
                         lv.name = e.name;
                         lv.start_pc = e.start_pc;
@@ -205,37 +213,39 @@ namespace IKVM.Runtime
             return allLocalVars;
         }
 
-        private static bool IsLoadLocal(NormalizedByteCode bc)
+        static bool IsLoadLocal(NormalizedByteCode bc)
         {
-            return bc == NormalizedByteCode.__aload ||
-                bc == NormalizedByteCode.__iload ||
-                bc == NormalizedByteCode.__lload ||
-                bc == NormalizedByteCode.__fload ||
-                bc == NormalizedByteCode.__dload ||
-                bc == NormalizedByteCode.__iinc ||
-                bc == NormalizedByteCode.__ret;
+            return bc is
+                NormalizedByteCode.__aload or
+                NormalizedByteCode.__iload or
+                NormalizedByteCode.__lload or
+                NormalizedByteCode.__fload or
+                NormalizedByteCode.__dload or
+                NormalizedByteCode.__iinc or
+                NormalizedByteCode.__ret;
         }
 
-        private static bool IsStoreLocal(NormalizedByteCode bc)
+        static bool IsStoreLocal(NormalizedByteCode bc)
         {
-            return bc == NormalizedByteCode.__astore ||
-                bc == NormalizedByteCode.__istore ||
-                bc == NormalizedByteCode.__lstore ||
-                bc == NormalizedByteCode.__fstore ||
-                bc == NormalizedByteCode.__dstore;
+            return bc is
+                NormalizedByteCode.__astore or
+                NormalizedByteCode.__istore or
+                NormalizedByteCode.__lstore or
+                NormalizedByteCode.__fstore or
+                NormalizedByteCode.__dstore;
         }
 
         struct FindLocalVarState
         {
+
             internal bool changed;
             internal FindLocalVarStoreSite[] sites;
 
             internal void Store(int instructionIndex, int localIndex)
             {
                 if (sites[localIndex].Count == 1 && sites[localIndex][0] == instructionIndex)
-                {
                     return;
-                }
+
                 sites = (FindLocalVarStoreSite[])sites.Clone();
                 sites[localIndex] = new FindLocalVarStoreSite();
                 sites[localIndex].Add(instructionIndex);
@@ -250,7 +260,7 @@ namespace IKVM.Runtime
                 }
                 else
                 {
-                    bool dirty = true;
+                    var dirty = true;
                     for (int i = 0; i < sites.Length; i++)
                     {
                         for (int j = 0; j < state.sites[i].Count; j++)
@@ -262,6 +272,7 @@ namespace IKVM.Runtime
                                     dirty = false;
                                     sites = (FindLocalVarStoreSite[])sites.Clone();
                                 }
+
                                 sites[i].Add(state.sites[i][j]);
                                 changed = true;
                             }
@@ -272,102 +283,89 @@ namespace IKVM.Runtime
 
             internal FindLocalVarState Copy()
             {
-                FindLocalVarState copy = new FindLocalVarState();
+                var copy = new FindLocalVarState();
                 copy.sites = sites;
                 return copy;
             }
 
             public override string ToString()
             {
-                System.Text.StringBuilder sb = new System.Text.StringBuilder();
+                var sb = new System.Text.StringBuilder();
                 if (sites != null)
                 {
-                    foreach (FindLocalVarStoreSite site in sites)
+                    foreach (var site in sites)
                     {
                         sb.Append('[');
+
                         for (int i = 0; i < site.Count; i++)
-                        {
                             sb.AppendFormat("{0}, ", site[i]);
-                        }
+
                         sb.Append(']');
                     }
                 }
+
                 return sb.ToString();
             }
         }
 
         struct FindLocalVarStoreSite
         {
-            private int[] data;
+
+            int[] data;
 
             internal bool Contains(int instructionIndex)
             {
                 if (data != null)
-                {
                     for (int i = 0; i < data.Length; i++)
-                    {
                         if (data[i] == instructionIndex)
-                        {
                             return true;
-                        }
-                    }
-                }
+
                 return false;
             }
 
             internal void Add(int instructionIndex)
             {
                 if (data == null)
-                {
-                    data = new int[] { instructionIndex };
-                }
+                    data = [instructionIndex];
                 else
-                {
                     data = ArrayUtil.Concat(data, instructionIndex);
-                }
             }
 
-            internal int this[int index]
-            {
-                get { return data[index]; }
-            }
+            internal int this[int index] => data[index];
 
-            internal int Count
-            {
-                get { return data == null ? 0 : data.Length; }
-            }
+            internal int Count => data == null ? 0 : data.Length;
+
         }
 
-        private static Dictionary<int, string>[] FindLocalVariables(CodeInfo codeInfo, RuntimeJavaMethod mw, ClassFile classFile, ClassFile.Method method)
+        static Dictionary<int, string>[] FindLocalVariables(CodeInfo codeInfo, RuntimeJavaMethod mw, ClassFile classFile, ClassFile.Method method)
         {
-            FindLocalVarState[] state = new FindLocalVarState[method.Instructions.Length];
+            var state = new FindLocalVarState[method.Instructions.Length];
             state[0].changed = true;
             state[0].sites = new FindLocalVarStoreSite[method.MaxLocals];
-            RuntimeJavaType[] parameters = mw.GetParameters();
+
+            var parameters = mw.GetParameters();
             int argpos = 0;
             if (!mw.IsStatic)
-            {
                 state[0].sites[argpos++].Add(-1);
-            }
+
             for (int i = 0; i < parameters.Length; i++)
             {
                 state[0].sites[argpos++].Add(-1);
                 if (parameters[i].IsWidePrimitive)
-                {
                     argpos++;
-                }
             }
+
             return FindLocalVariablesImpl(mw.DeclaringType.Context, codeInfo, classFile, method, state);
         }
 
-        private static Dictionary<int, string>[] FindLocalVariablesImpl(RuntimeContext context, CodeInfo codeInfo, ClassFile classFile, ClassFile.Method method, FindLocalVarState[] state)
+        static Dictionary<int, string>[] FindLocalVariablesImpl(RuntimeContext context, CodeInfo codeInfo, ClassFile classFile, ClassFile.Method method, FindLocalVarState[] state)
         {
-            ClassFile.Method.Instruction[] instructions = method.Instructions;
-            ExceptionTableEntry[] exceptions = method.ExceptionTable;
-            int maxLocals = method.MaxLocals;
-            Dictionary<int, string>[] localStoreReaders = new Dictionary<int, string>[instructions.Length];
-            bool done = false;
+            var instructions = method.Instructions;
+            var exceptions = method.ExceptionTable;
+            var maxLocals = method.MaxLocals;
+            var localStoreReaders = new Dictionary<int, string>[instructions.Length];
 
+            var done = false;
             while (!done)
             {
                 done = true;
@@ -378,62 +376,42 @@ namespace IKVM.Runtime
                         done = false;
                         state[i].changed = false;
 
-                        FindLocalVarState curr = state[i].Copy();
+                        var curr = state[i].Copy();
 
                         for (int j = 0; j < exceptions.Length; j++)
-                        {
                             if (exceptions[j].startIndex <= i && i < exceptions[j].endIndex)
-                            {
                                 state[exceptions[j].handlerIndex].Merge(curr);
-                            }
-                        }
 
-                        if (IsLoadLocal(instructions[i].NormalizedOpCode)
-                            && (instructions[i].NormalizedOpCode != NormalizedByteCode.__aload || !RuntimeVerifierJavaType.IsFaultBlockException(codeInfo.GetRawStackTypeWrapper(i + 1, 0))))
+                        if (IsLoadLocal(instructions[i].NormalizedOpCode) && (instructions[i].NormalizedOpCode != NormalizedByteCode.__aload || !RuntimeVerifierJavaType.IsFaultBlockException(codeInfo.GetRawStackTypeWrapper(i + 1, 0))))
                         {
-                            if (localStoreReaders[i] == null)
-                            {
-                                localStoreReaders[i] = new Dictionary<int, string>();
-                            }
+                            localStoreReaders[i] ??= new Dictionary<int, string>();
+
                             for (int j = 0; j < curr.sites[instructions[i].NormalizedArg1].Count; j++)
-                            {
                                 localStoreReaders[i][curr.sites[instructions[i].NormalizedArg1][j]] = "";
-                            }
                         }
 
-                        if (IsStoreLocal(instructions[i].NormalizedOpCode)
-                            && (instructions[i].NormalizedOpCode != NormalizedByteCode.__astore || !RuntimeVerifierJavaType.IsFaultBlockException(codeInfo.GetRawStackTypeWrapper(i, 0))))
+                        if (IsStoreLocal(instructions[i].NormalizedOpCode) && (instructions[i].NormalizedOpCode != NormalizedByteCode.__astore || !RuntimeVerifierJavaType.IsFaultBlockException(codeInfo.GetRawStackTypeWrapper(i, 0))))
                         {
                             curr.Store(i, instructions[i].NormalizedArg1);
+
                             // if this is a store at the end of an exception block,
                             // we need to propagate the new state to the exception handler
                             for (int j = 0; j < exceptions.Length; j++)
-                            {
                                 if (exceptions[j].endIndex == i + 1)
-                                {
                                     state[exceptions[j].handlerIndex].Merge(curr);
-                                }
-                            }
                         }
 
                         if (instructions[i].NormalizedOpCode == NormalizedByteCode.__invokespecial)
                         {
-                            ClassFile.ConstantPoolItemMI cpi = classFile.GetMethodref(instructions[i].Arg1);
+                            var cpi = classFile.GetMethodref(instructions[i].Arg1);
                             if (ReferenceEquals(cpi.Name, StringConstants.INIT))
                             {
-                                RuntimeJavaType type = codeInfo.GetRawStackTypeWrapper(i, cpi.GetArgTypes().Length);
-                                // after we've invoked the constructor, the uninitialized references
-                                // are now initialized
+                                var type = codeInfo.GetRawStackTypeWrapper(i, cpi.GetArgTypes().Length);
+                                // after we've invoked the constructor, the uninitialized references are now initialized
                                 if (type == context.VerifierJavaTypeFactory.UninitializedThis || RuntimeVerifierJavaType.IsNew(type))
-                                {
                                     for (int j = 0; j < maxLocals; j++)
-                                    {
                                         if (codeInfo.GetLocalTypeWrapper(i, j) == type)
-                                        {
                                             curr.Store(i, j);
-                                        }
-                                    }
-                                }
                             }
                         }
                         else if (instructions[i].NormalizedOpCode == NormalizedByteCode.__goto_finally)
@@ -469,9 +447,8 @@ namespace IKVM.Runtime
                             case ByteCodeFlowControl.Switch:
                                 {
                                     for (int j = 0; j < instructions[i].SwitchEntryCount; j++)
-                                    {
                                         state[instructions[i].GetSwitchTargetIndex(j)].Merge(curr);
-                                    }
+
                                     state[instructions[i].DefaultTarget].Merge(curr);
                                     break;
                                 }
@@ -494,16 +471,18 @@ namespace IKVM.Runtime
                     }
                 }
             }
+
             return localStoreReaders;
         }
 
-        private static void VisitLocalLoads(RuntimeContext context, CodeInfo codeInfo, ClassFile.Method method, List<LocalVar> locals, Dictionary<long, LocalVar> localByStoreSite, Dictionary<int, string> storeSites, int instructionIndex, bool debug)
+        static void VisitLocalLoads(RuntimeContext context, CodeInfo codeInfo, ClassFile.Method method, List<LocalVar> locals, Dictionary<long, LocalVar> localByStoreSite, Dictionary<int, string> storeSites, int instructionIndex, bool debug)
         {
             Debug.Assert(IsLoadLocal(method.Instructions[instructionIndex].NormalizedOpCode));
+
             LocalVar local = null;
-            RuntimeJavaType type = context.VerifierJavaTypeFactory.Null;
-            int localIndex = method.Instructions[instructionIndex].NormalizedArg1;
-            bool isArg = false;
+            var type = context.VerifierJavaTypeFactory.Null;
+            var localIndex = method.Instructions[instructionIndex].NormalizedArg1;
+            var isArg = false;
             foreach (int store in storeSites.Keys)
             {
                 if (store == -1)
@@ -532,8 +511,7 @@ namespace IKVM.Runtime
                 // we can't have an invalid type, because that would have failed verification earlier
                 Debug.Assert(type != context.VerifierJavaTypeFactory.Invalid);
 
-                LocalVar l;
-                if (localByStoreSite.TryGetValue(MakeKey(store, localIndex), out l))
+                if (localByStoreSite.TryGetValue(MakeKey(store, localIndex), out var l))
                 {
                     if (local == null)
                     {
@@ -554,23 +532,17 @@ namespace IKVM.Runtime
                     }
                 }
             }
+
             if (local == null)
             {
                 local = new LocalVar();
                 local.local = localIndex;
-                if (RuntimeVerifierJavaType.IsThis(type))
-                {
-                    local.type = ((RuntimeVerifierJavaType)type).UnderlyingType;
-                }
-                else
-                {
-                    local.type = type;
-                }
+                local.type = RuntimeVerifierJavaType.IsThis(type) ? ((RuntimeVerifierJavaType)type).UnderlyingType : type;
                 local.isArg = isArg;
+
                 if (debug)
-                {
                     FindLvtEntry(local, method, instructionIndex);
-                }
+
                 locals.Add(local);
             }
             else
@@ -579,10 +551,10 @@ namespace IKVM.Runtime
                 local.type = InstructionState.FindCommonBaseType(context, local.type, type);
                 Debug.Assert(local.type != context.VerifierJavaTypeFactory.Invalid);
             }
+
             foreach (int store in storeSites.Keys)
             {
-                LocalVar v;
-                if (!localByStoreSite.TryGetValue(MakeKey(store, localIndex), out v))
+                if (!localByStoreSite.TryGetValue(MakeKey(store, localIndex), out var v))
                 {
                     localByStoreSite[MakeKey(store, localIndex)] = local;
                 }
@@ -593,15 +565,16 @@ namespace IKVM.Runtime
             }
         }
 
-        private static long MakeKey(int i, int j)
+        static long MakeKey(int i, int j)
         {
             return (((long)(uint)i) << 32) + (uint)j;
         }
 
-        private static LocalVar MergeLocals(RuntimeContext context, List<LocalVar> locals, Dictionary<long, LocalVar> localByStoreSite, LocalVar l1, LocalVar l2)
+        static LocalVar MergeLocals(RuntimeContext context, List<LocalVar> locals, Dictionary<long, LocalVar> localByStoreSite, LocalVar l1, LocalVar l2)
         {
             Debug.Assert(l1 != l2);
             Debug.Assert(l1.local == l2.local);
+
             for (int i = 0; i < locals.Count; i++)
             {
                 if (locals[i] == l2)
@@ -610,15 +583,16 @@ namespace IKVM.Runtime
                     i--;
                 }
             }
-            Dictionary<long, LocalVar> temp = new Dictionary<long, LocalVar>(localByStoreSite);
+
+            var temp = new Dictionary<long, LocalVar>(localByStoreSite);
             localByStoreSite.Clear();
-            foreach (KeyValuePair<long, LocalVar> kv in temp)
-            {
+            foreach (var kv in temp)
                 localByStoreSite[kv.Key] = kv.Value == l2 ? l1 : kv.Value;
-            }
+
             l1.isArg |= l2.isArg;
             l1.type = InstructionState.FindCommonBaseType(context, l1.type, l2.type);
             Debug.Assert(l1.type != context.VerifierJavaTypeFactory.Invalid);
+
             return l1;
         }
     }

--- a/src/IKVM.Runtime/LocalVarInfo.cs
+++ b/src/IKVM.Runtime/LocalVarInfo.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 
 using InstructionFlags = IKVM.Runtime.ClassFile.Method.InstructionFlags;
 
@@ -290,7 +291,8 @@ namespace IKVM.Runtime
 
             public override string ToString()
             {
-                var sb = new System.Text.StringBuilder();
+                var sb = new ValueStringBuilder();
+
                 if (sites != null)
                 {
                     foreach (var site in sites)
@@ -298,7 +300,10 @@ namespace IKVM.Runtime
                         sb.Append('[');
 
                         for (int i = 0; i < site.Count; i++)
-                            sb.AppendFormat("{0}, ", site[i]);
+                        {
+                            sb.Append(site[i].ToString());
+                            sb.Append(", ");
+                        }
 
                         sb.Append(']');
                     }
@@ -325,15 +330,12 @@ namespace IKVM.Runtime
 
             internal void Add(int instructionIndex)
             {
-                if (data == null)
-                    data = [instructionIndex];
-                else
-                    data = ArrayUtil.Concat(data, instructionIndex);
+                data = data == null ? [instructionIndex] : [.. data, instructionIndex];
             }
 
-            internal int this[int index] => data[index];
+            internal readonly int this[int index] => data[index];
 
-            internal int Count => data == null ? 0 : data.Length;
+            internal readonly int Count => data == null ? 0 : data.Length;
 
         }
 

--- a/src/IKVM.Runtime/MethodAnalyzerFactory.cs
+++ b/src/IKVM.Runtime/MethodAnalyzerFactory.cs
@@ -1,0 +1,86 @@
+﻿/*
+  Copyright (C) 2002-2014 Jeroen Frijters
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jeroen Frijters
+  jeroen@frijters.net
+  
+*/
+using System;
+
+#if IMPORTER
+using IKVM.Tools.Importer;
+#endif
+
+
+namespace IKVM.Runtime
+{
+    /// <summary>
+    /// Provides instances of <see cref="MethodAnalyzer"/>.
+    /// </summary>
+    class MethodAnalyzerFactory
+    {
+
+        readonly RuntimeContext _context;
+
+        public readonly RuntimeJavaType ByteArrayType;
+        public readonly RuntimeJavaType BooleanArrayType;
+        public readonly RuntimeJavaType ShortArrayType;
+        public readonly RuntimeJavaType CharArrayType;
+        public readonly RuntimeJavaType IntArrayType;
+        public readonly RuntimeJavaType FloatArrayType;
+        public readonly RuntimeJavaType DoubleArrayType;
+        public readonly RuntimeJavaType LongArrayType;
+        public readonly RuntimeJavaType JavaLangThreadDeathType;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="context"></param>
+        public MethodAnalyzerFactory(RuntimeContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            ByteArrayType = context.PrimitiveJavaTypeFactory.BYTE.MakeArrayType(1);
+            BooleanArrayType = context.PrimitiveJavaTypeFactory.BOOLEAN.MakeArrayType(1);
+            ShortArrayType = context.PrimitiveJavaTypeFactory.SHORT.MakeArrayType(1);
+            CharArrayType = context.PrimitiveJavaTypeFactory.CHAR.MakeArrayType(1);
+            IntArrayType = context.PrimitiveJavaTypeFactory.INT.MakeArrayType(1);
+            FloatArrayType = context.PrimitiveJavaTypeFactory.FLOAT.MakeArrayType(1);
+            DoubleArrayType = context.PrimitiveJavaTypeFactory.DOUBLE.MakeArrayType(1);
+            LongArrayType = context.PrimitiveJavaTypeFactory.LONG.MakeArrayType(1);
+            JavaLangThreadDeathType = context.ClassLoaderFactory.LoadClassCritical("java.lang.ThreadDeath");
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="MethodAnalyzer"/>.
+        /// </summary>
+        /// <param name="host"></param>
+        /// <param name="wrapper"></param>
+        /// <param name="mw"></param>
+        /// <param name="classFile"></param>
+        /// <param name="method"></param>
+        /// <param name="classLoader"></param>
+        /// <returns></returns>
+        public MethodAnalyzer Create(RuntimeJavaType host, RuntimeJavaType wrapper, RuntimeJavaMethod mw, ClassFile classFile, ClassFile.Method method, RuntimeClassLoader classLoader)
+        {
+            return new MethodAnalyzer(_context, host, wrapper, mw, classFile, method, classLoader);
+        }
+
+    }
+
+}

--- a/src/IKVM.Runtime/RuntimeJavaType.cs
+++ b/src/IKVM.Runtime/RuntimeJavaType.cs
@@ -27,6 +27,8 @@ using System.Diagnostics;
 
 using IKVM.Attributes;
 using IKVM.CoreLib.Diagnostics;
+using System.Runtime.CompilerServices;
+
 
 #if IMPORTER || EXPORTER
 using IKVM.Reflection;

--- a/src/IKVM.Runtime/RuntimeJavaType.cs
+++ b/src/IKVM.Runtime/RuntimeJavaType.cs
@@ -27,8 +27,6 @@ using System.Diagnostics;
 
 using IKVM.Attributes;
 using IKVM.CoreLib.Diagnostics;
-using System.Runtime.CompilerServices;
-
 
 #if IMPORTER || EXPORTER
 using IKVM.Reflection;

--- a/src/IKVM.Runtime/RuntimeVerifierJavaType.cs
+++ b/src/IKVM.Runtime/RuntimeVerifierJavaType.cs
@@ -170,7 +170,7 @@ namespace IKVM.Runtime
 
         internal static void ClearFaultBlockException(RuntimeJavaType w)
         {
-            RuntimeVerifierJavaType vtw = (RuntimeVerifierJavaType)w;
+            var vtw = (RuntimeVerifierJavaType)w;
             vtw.methodAnalyzer.ClearFaultBlockException(vtw.Index);
         }
 


### PR DESCRIPTION
Data flow analysis merges types. Presently, if either side is an interface, java.lang.Object is considered the common base type. This is incorrect. The proper logic would be that if BOTH sides are an interface jlo should be used. However, if only one side is an interface, that interface is the common base type if it is implemented by the other side.

This is a selective merge from develop to main.

Fixes #662 