### PR TITLE
Force NoOptimization on JNIEnvContext.Current property accessors

### DIFF
--- a/src/IKVM.Runtime/JNI/JNIEnvContext.cs
+++ b/src/IKVM.Runtime/JNI/JNIEnvContext.cs
@@ -23,6 +23,7 @@
 */
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace IKVM.Runtime.JNI
 {
@@ -46,8 +47,8 @@ namespace IKVM.Runtime.JNI
         /// </summary>
         internal static JNIEnvContext Current
         {
-            get => current;
-            set => current = value;
+            [MethodImpl(MethodImplOptions.NoOptimization)] get => current;
+            [MethodImpl(MethodImplOptions.NoOptimization)] set => current = value;
         }
 
         internal const int JNI_OK = 0;


### PR DESCRIPTION
As discussed in [dotnet/runtime#119725](https://redirect.github.com/dotnet/runtime/issues/119725), appeared in [iterate-ch/cyberduck#17443](https://redirect.github.com/iterate-ch/cyberduck/issues/17443).

Verified locally, enforcing no optimizations fixes a thread static AccessViolation in JNIEnvContext.Current.