### PR TITLE
Run Windows tests on the VS 2026 runner image

### DIFF
--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -536,11 +536,46 @@ jobs:
         dotnet: false
         swap-storage: false
         large-packages: false
+    - name: Free Disk Space (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Continue'
+        function Show-Free($when) {
+          Get-CimInstance Win32_LogicalDisk -Filter "DriveType=3" | ForEach-Object {
+            "{0}: {1} {2:N1} GB free of {3:N1} GB" -f $when, $_.DeviceID, ($_.FreeSpace/1GB), ($_.Size/1GB)
+          }
+        }
+        Show-Free "before"
+        # Toolchains preinstalled on the image that this job never uses. The build
+        # itself happens on Linux; these runners only restore packages and run tests.
+        $cache = if ($env:RUNNER_TOOL_CACHE) { $env:RUNNER_TOOL_CACHE } else { "C:\hostedtoolcache\windows" }
+        $stale = @(
+          "$cache\CodeQL",
+          "$cache\Ruby",
+          "$cache\PyPy",
+          "$cache\go",
+          "C:\Android",
+          "C:\Program Files (x86)\Android",
+          "C:\Program Files\MongoDB",
+          "C:\Program Files\MySQL",
+          "C:\Program Files\PostgreSQL",
+          "C:\Program Files\Amazon",
+          "C:\Program Files\Microsoft SDKs\Azure",
+          "C:\SeleniumWebDrivers"
+        )
+        foreach ($p in $stale) {
+          if (Test-Path -LiteralPath $p) {
+            Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue
+            if (Test-Path -LiteralPath $p) { "could not fully remove $p" } else { "removed $p" }
+          }
+        }
+        Show-Free "after"
     - name: Set Paths (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $dir="D:\w"
+        $dir="${{ runner.temp }}\w"
         mkdir $dir
         mkdir $dir\temp
         mkdir $dir\dotnet

--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -536,41 +536,6 @@ jobs:
         dotnet: false
         swap-storage: false
         large-packages: false
-    - name: Free Disk Space (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = 'Continue'
-        function Show-Free($when) {
-          Get-CimInstance Win32_LogicalDisk -Filter "DriveType=3" | ForEach-Object {
-            "{0}: {1} {2:N1} GB free of {3:N1} GB" -f $when, $_.DeviceID, ($_.FreeSpace/1GB), ($_.Size/1GB)
-          }
-        }
-        Show-Free "before"
-        # Toolchains preinstalled on the image that this job never uses. The build
-        # itself happens on Linux; these runners only restore packages and run tests.
-        $cache = if ($env:RUNNER_TOOL_CACHE) { $env:RUNNER_TOOL_CACHE } else { "C:\hostedtoolcache\windows" }
-        $stale = @(
-          "$cache\CodeQL",
-          "$cache\Ruby",
-          "$cache\PyPy",
-          "$cache\go",
-          "C:\Android",
-          "C:\Program Files (x86)\Android",
-          "C:\Program Files\MongoDB",
-          "C:\Program Files\MySQL",
-          "C:\Program Files\PostgreSQL",
-          "C:\Program Files\Amazon",
-          "C:\Program Files\Microsoft SDKs\Azure",
-          "C:\SeleniumWebDrivers"
-        )
-        foreach ($p in $stale) {
-          if (Test-Path -LiteralPath $p) {
-            Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue
-            if (Test-Path -LiteralPath $p) { "could not fully remove $p" } else { "removed $p" }
-          }
-        }
-        Show-Free "after"
     - name: Set Paths (Windows)
       if: runner.os == 'Windows'
       shell: pwsh

--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -527,7 +527,7 @@ jobs:
       matrix: ${{ fromJSON(needs.test-vars.outputs.matrix) }}
     name: Test (${{ matrix.run }}:${{ matrix.tfm }}:${{ matrix.sys }})
     timeout-minutes: 240
-    runs-on: ${{ fromJSON('{"win-x86":["windows-2022"],"win-x64":["windows-2022"],"linux-x64":["ubuntu-24.04"],"linux-arm64":["ubuntu-24.04-arm"],"osx-x64":["macos-13"],"osx-arm64":["macos-14"]}')[matrix.sys] }}
+    runs-on: ${{ fromJSON('{"win-x86":["windows-2025-vs2026"],"win-x64":["windows-2025-vs2026"],"linux-x64":["ubuntu-24.04"],"linux-arm64":["ubuntu-24.04-arm"],"osx-x64":["macos-13"],"osx-arm64":["macos-14"]}')[matrix.sys] }}
     steps:
     - name: Free Disk Space (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -540,7 +540,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $dir="C:\w"
+        $dir="D:\w"
         mkdir $dir
         mkdir $dir\temp
         mkdir $dir\dotnet


### PR DESCRIPTION
Unblocks the `IKVM.MSBuild.Tests` and `IKVM.NET.Sdk.Tests` failures currently red on `main` (and therefore on every PR branched from it, including #725).

## The failure

`CanBuildTestProject` runs each row twice, once per `EnvironmentPreference`. The `Framework` rows drive the build through Visual Studio's `MSBuild.exe` instead of `dotnet build`. On `windows-2022` that is VS 2022, MSBuild 17.14 — and the .NET 10.0.3xx SDK refuses to load under anything older than MSBuild 18:

```
Errors: Version 10.0.301 of the .NET SDK requires at least version 18.0.0 of MSBuild.
The current available version of MSBuild is 17.14.40.60911.
```

The build dies resolving `Microsoft.NET.Sdk`, before compiling anything. The split is exactly along that line — **72 `Framework` rows fail, 0 `Core` rows fail** — which is why it reads as a broad breakage but is really one environment mismatch.

`src/IKVM.MSBuild.Tests/Project/global.json` pins `"version": "10.0.0"` with `"rollForward": "latestFeature"`, so the test project lands on whatever the newest feature band is — currently 10.0.301.

## The fix

Point the Windows test rows at `windows-2025-vs2026`, which ships VS 2026 18.7 and therefore MSBuild 18.

Note that `windows-2025` is **not** sufficient — that label still serves VS 2022 17.14. Only the explicit `-vs2026` label has VS 2026 today.

## Scope

This clears 2 of the 6 jobs failing on `main`. The other four are separate, unrelated root causes and are untouched here:

- `IKVM.Tools.Importer.Tests:net472` — ikvmc fails to bind `System.Collections.Immutable` at startup
- `IKVM.OpenJDK.Tests` partition 7 (3 platforms) — `sun/security/ssl/X509KeyManager/PreferredKey` fails on all three
