### PR TITLE
DIAGNOSTIC (do not merge): assembly bind logging for net472 importer tests

### DIFF
--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -666,6 +666,22 @@ jobs:
       shell: pwsh
       run: ri tests--${{ steps.test-name.outputs.result }}.tar.gz
       working-directory: ${{ env.WORKPATH }}
+    # TEMPORARY DIAGNOSTIC: identify what requests System.Collections.Immutable 10.0.0.0
+    # in the net472 importer tests. Remove once the binding failure is understood.
+    - name: Enable Assembly Binding Log (Windows)
+      if: runner.os == 'Windows' && contains(matrix.run, 'IKVM.Tools.Importer.Tests')
+      shell: pwsh
+      run: |
+        $dir = "$env:WORKPATH\fusion"
+        mkdir $dir -Force | Out-Null
+        $key = "HKLM:\SOFTWARE\Microsoft\Fusion"
+        New-Item -Path $key -Force | Out-Null
+        New-ItemProperty -Path $key -Name "EnableLog" -Value 1 -PropertyType DWord -Force | Out-Null
+        New-ItemProperty -Path $key -Name "LogFailures" -Value 1 -PropertyType DWord -Force | Out-Null
+        New-ItemProperty -Path $key -Name "LogResourceBinds" -Value 0 -PropertyType DWord -Force | Out-Null
+        New-ItemProperty -Path $key -Name "LogPath" -Value "$dir\" -PropertyType String -Force | Out-Null
+        Add-Content $env:GITHUB_ENV "`nFUSIONLOG=$dir`n"
+        "Assembly bind failure logging enabled at $dir"
     - name: Execute Tests
       timeout-minutes: 120
       shell: pwsh
@@ -722,6 +738,23 @@ jobs:
             dotnet test @argl $tests[0].FullName
         }
       working-directory: ${{ env.WORKPATH }}
+    # TEMPORARY DIAGNOSTIC: see "Enable Assembly Binding Log (Windows)" above.
+    - name: Dump Assembly Binding Log (Windows)
+      if: always() && runner.os == 'Windows' && contains(matrix.run, 'IKVM.Tools.Importer.Tests')
+      shell: pwsh
+      run: |
+        if (-not (Test-Path $env:FUSIONLOG)) { "No fusion log directory."; exit 0 }
+        $logs = Get-ChildItem $env:FUSIONLOG -Recurse -Filter "*.HTM" -ErrorAction SilentlyContinue
+        "Found $($logs.Count) bind failure log(s)."
+        $hits = $logs | Where-Object { (Get-Content $_.FullName -Raw) -match "System\.Collections\.Immutable" }
+        "Of those, $($hits.Count) mention System.Collections.Immutable."
+        foreach ($h in $hits | Select-Object -First 10) {
+            "".PadRight(78, '=')
+            "FILE: $($h.FullName)"
+            # strip HTML tags so the bind detail is readable in the job log
+            ((Get-Content $h.FullName -Raw) -replace '<[^>]+>', '') -split "`n" |
+                Where-Object { $_.Trim() } | ForEach-Object { $_.Trim() }
+        }
     - name: Archive Test Results
       if: always() && startsWith(env.RET, 'TestResults--')
       run: tar czvf ${{ env.TMPDIR }}/TestResults.tar.gz TestResults


### PR DESCRIPTION
**Draft, not for merge.** Temporary instrumentation to identify one unknown, then revert.

## Why

`IKVM.Tools.Importer.Tests` on net472 fails every row on `main` with:

```
Could not load file or assembly 'System.Collections.Immutable, Version=10.0.0.0' ...
 ---> Could not load file or assembly 'System.Collections.Immutable, Version=8.0.0.0' ...
   at IKVM.Tools.Importer.ImportOptions..ctor()
```

The generated `IKVM.Tools.Importer.Tests.exe.config` contains:

```xml
<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
<bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
```

A **10.0.0.0** reference falls outside `0.0.0.0-8.0.0.0`, so the redirect never applies and the loader binds 10.0.0.0 literally against a file that really is 8.0.0.0 (FileVersion 8.0.23.53103). That much is confirmed from the run 29223646609 artifact.

## The unknown

Nothing I can enumerate explains where the 10.0.0.0 reference comes from. Checked and ruled out:

- all 68 assemblies in `tests/IKVM.Tools.Importer.Tests/net472/` — highest is 8.0.0.0 (`IKVM.CoreLib`, `IKVM.Tools.Importer`, `System.Reflection.Metadata`); the rest ask for 1.2.3.0–6.0.0.0
- `IKVM.Runtime.dll` / `IKVM.Java.dll` — no reference to it at all
- SDK 10.0.302 TestPlatform / TestHost / diagnostics assemblies — none reference version ≥ 9

The failing run logs `WRN: Assembly binding logging is turned OFF.`, so this turns it on and prints any bind-failure log naming the assembly. That names the requester directly instead of guessing.

## Changes

Two steps in the `test` job, both gated to Windows + `IKVM.Tools.Importer.Tests`:

- **Enable Assembly Binding Log** — sets `HKLM\SOFTWARE\Microsoft\Fusion` `LogFailures`/`EnableLog` with a `LogPath` under the work dir
- **Dump Assembly Binding Log** — `if: always()`, strips HTML and prints matching failure logs to the job output

Once the requester is known, this is reverted and the real fix goes in separately.

Related: this is one of the failures blocking #725, whose own change is correct and adds no failures of its own.
