### PR TITLE
Exclude PreferredKey, whose test certificate expired

### DIFF
--- a/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
+++ b/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
@@ -3076,6 +3076,15 @@ sun/security/ssl/EngineArgs/DebugReportsOneExtraByte.sh                         
 sun/security/ssl/SSLEngineImpl/SSLEngineDeadlock.java                                                                   generic-all
 sun/security/ssl/SSLSocketImpl/NotifyHandshakeTest.sh                                                                   generic-all
 sun/security/ssl/Stapling/StatusResponseManager.sh                                                                      generic-all
+# The PreferredKey.java entry immediately below is excluded because its test
+# data expired, not because of anything in IKVM. The RSA certificate in
+# javax/net/ssl/etc/keystore ran out on 2026-05-16, so chooseClientAlias picks
+# the still-valid DSA key over the expired RSA one and the test's assertion
+# fails. Verified by running the same calls on a stock JDK 8, which returns DSA
+# too. Partition 7 passed on 2026-04-26 and has failed on every run since.
+# Remove this once upstream regenerates the keystore.
+sun/security/ssl/X509KeyManager/PreferredKey.java                                                                       generic-all
+
 sun/security/ssl/internal/TestRun.sh                                                                                    generic-all
 sun/security/ssl/sanity/pluggability/CheckSSLContextExport.java                                                         generic-all
 sun/security/ssl/templates/SSLEngineTemplate.java                                                                       generic-all


### PR DESCRIPTION
`sun/security/ssl/X509KeyManager/PreferredKey.java` has failed on all three platforms since May. It is one of the two deterministic failures blocking #727, #730 and #731 — and it is not an IKVM problem.

## What the test wants

It asks a `NewSunX509` key manager for a client alias with key types `{RSA, DSA}` and requires an RSA key back — the point of bug 6302644, that the most preferred key type wins.

## Why it stopped working

The keystore it uses, `javax/net/ssl/etc/keystore`:

```
dummy    (RSA): valid until Sat May 16 2026     <- expired
dummydsa (DSA): valid until Tue Mar 28 2028     <- still valid
```

Now that the RSA certificate has lapsed, its `CheckResult` is `EXPIRED` rather than `OK`. `getAliases` only short-circuits on `checkResult == OK && keyIndex == 0`, so the RSA entry no longer returns early. Both entries accumulate, `Collections.sort` puts `OK` ahead of `EXPIRED`, and the DSA key comes out first. The test sees DSA where it demanded RSA and throws.

## Confirmed two ways

**It fails on a stock JDK.** Running the same three calls against the same keystore on Adoptium JDK 8 — no IKVM involved:

```
getClientAliases(RSA)      = [1.0.dummy]
chooseClientAlias(RSA,DSA) = 2.0.dummydsa
  -> algorithm = DSA
EXPECTED by test: algorithm == RSA
```

**The dates line up exactly.** Partition 7 passed on 2026-04-26 (run on #716) and has failed on every run since. The certificate expired 2026-05-16, in between.

## Scope

Excluded rather than fixed, because the fix belongs upstream in regenerating the test data. The comment in the file records that so the entry can be dropped when that happens.

Worth noting: 81 tests use that keystore and three of its certificates expired on the same day, so more may surface over time. Only this one is failing today.

## Effect

With this and the `System.Collections.Immutable` bind (#732), the deterministic failures are accounted for. Applied on top of #727, a run should reduce to flakes only.
