### PR TITLE
Use LLVM 20 throughout the Linux build

### DIFF
--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -137,7 +137,7 @@ jobs:
     - name: Install LLVM and Clang
       run: |
         sudo apt-get update && \
-        sudo apt-get install -y clang-20 llvm-20 && \
+        sudo apt-get install -y clang-20 llvm-20 lld-20 && \
         echo "PATH=/usr/lib/llvm-20/bin:$PATH" >> $GITHUB_ENV
     - name: Install apple-codesign
       uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -138,7 +138,7 @@ jobs:
       run: |
         sudo apt-get update && \
         sudo apt-get install -y clang-20 llvm-20 && \
-        echo "PATH=/usr/lib/llvm-18/bin:$PATH" >> $GITHUB_ENV
+        echo "PATH=/usr/lib/llvm-20/bin:$PATH" >> $GITHUB_ENV
     - name: Install apple-codesign
       uses: baptiste0928/cargo-install@v3
       with:


### PR DESCRIPTION
Makes the Linux build use LLVM 20 throughout, instead of depending on whichever LLVM the runner image happens to ship.

## What was there

```yaml
sudo apt-get install -y clang-20 llvm-20 && \
echo "PATH=/usr/lib/llvm-18/bin:$PATH" >> $GITHUB_ENV
```

Install 20, then put **18** on `PATH`.

## What I got wrong first

My initial reading was that the llvm-18 entry was dead, since nothing installs llvm-18. CI disagreed immediately — changing it to llvm-20 broke the build with:

```
error : unable to execute command: Executable "lld-link" doesn't exist!
error : invalid linker name in argument '-fuse-ld=lld'
```

which is the same failure that was blocking #716 at the start of this work.

The runner image ships its own LLVM 18, and `/usr/lib/llvm-18/bin` was supplying `lld`. The entry was not dead — it was the only thing providing a linker. The apt `llvm-20` package does not include lld; that lives in a separate `lld-20`.

## What this does

```yaml
sudo apt-get install -y clang-20 llvm-20 lld-20 && \
echo "PATH=/usr/lib/llvm-20/bin:$PATH" >> $GITHUB_ENV
```

Every toolchain reference in the workflow is now on 20:

| | |
|---|---|
| installed | `clang-20`, `llvm-20`, `lld-20` |
| `PATH` | `/usr/lib/llvm-20/bin` |
| `ClangToolExe` | `/usr/bin/clang-20` (already) |
| `LlvmArToolExe` | `/usr/bin/llvm-ar-20` (already) |

`-fuse-ld=lld` comes from `IKVM.Clang.Sdk` rather than this repo, so it resolves lld off `PATH` — which is why the version there matters.

## Why it is worth doing

The build was silently linking with LLVM 18's lld while compiling with clang 20. It worked, but only because the image happened to carry a matching-enough LLVM. That is what made the original `lld-link` failure so hard to place: the dependency was on the image, not on anything the workflow declared.
