### PR TITLE
Update to jdk8u482-b08

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
         <OpenJdkMajorVersion>1</OpenJdkMajorVersion>
         <OpenJdkMinorVersion>8</OpenJdkMinorVersion>
         <OpenJdkMicroVersion>0</OpenJdkMicroVersion>
-        <OpenJdkUpdateVersion>472</OpenJdkUpdateVersion>
+        <OpenJdkUpdateVersion>482</OpenJdkUpdateVersion>
         <OpenJdkBuildNumber>b08</OpenJdkBuildNumber>
         <OpenJdkVersion>OpenJDK $(OpenJdkMinorVersion)u$(OpenJdkUpdateVersion) $(OpenJdkBuildNumber)</OpenJdkVersion>
         <OpenJdkFullVersion>$(OpenJdkMajorVersion).$(OpenJdkMinorVersion).$(OpenJdkMicroVersion)_$(OpenJdkUpdateVersion)-$(OpenJdkBuildNumber)</OpenJdkFullVersion>

--- a/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
+++ b/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
@@ -4294,3 +4294,10 @@ sun/java2d/cmm/ColorConvertOp/ConstructorsNullTest/ConstructorsNullTest.java    
 java/nio/channels/etc/AdaptorCloseAndInterrupt.java                                                                     generic-all
 # fails on net8.0 linux-x64
 java/awt/Focus/6401036/InputVerifierTest2.java                                                                          generic-all
+
+# Began failing with the move to jdk8u482-b08 and were excluded as part of
+# that upgrade. Carried across unchanged; none has been investigated, so the
+# reason each fails is not recorded here.
+javax/swing/DefaultButtonModel/DefaultButtonModelCrashTest.java                                                         generic-all
+javax/swing/JFileChooser/FileSystemView/Win32FolderSort.java                                                            generic-all
+lib/property/CheckWindowsProperty.java                                                                                  generic-all


### PR DESCRIPTION
Updates OpenJDK from 8u472 to 8u482-b08. This is #716 rebuilt on `main`.

## Why not just rebase #716

#716 targets `develop`, which has had no commits since 26 April and none of the CI work from the last few days. Nothing on that branch could run cleanly regardless of its content, which is most of why it has sat unmerged.

## What is here

| File | Change |
|---|---|
| `Directory.Build.props` | `OpenJdkUpdateVersion` 472 → 482 (`OpenJdkBuildNumber` is already `b08`) |
| `ext/openjdk` | submodule → `69137c64`, the tip of `ikvm-jdk8u482-b08` |
| `ExcludeList.txt` | three tests that began failing with the update |

## What was dropped

#716 also carried two workflow changes — moving the Windows runners to `windows-2025` and staging work under `D:`. Both were attempts at the MSBuild and disk problems that #727 has since solved properly, with `windows-2025-vs2026` and `runner.temp`. Carrying them across would undo that.

Two of its five exclude-list changes have already landed independently, which is worth noting as corroboration rather than duplication:

- **`AsyncClose`** — #716 widened it to `generic-all` with the note that it "used to work at one point on Windows, but it seems to have regressed". #730 arrived at the same place from the other direction, after it turned up as an intermittent Windows failure across five runs.
- **`ModalDialogInitialFocusTest`** — landed in #731.

The remaining three are carried over unchanged:

```
javax/swing/DefaultButtonModel/DefaultButtonModelCrashTest.java
javax/swing/JFileChooser/FileSystemView/Win32FolderSort.java
lib/property/CheckWindowsProperty.java
```

They are annotated as having begun failing with this upgrade. None has been investigated, and the comment says so rather than implying a cause is known.

## What this needs from CI

The original #716 ran its OpenJDK suite clean — all 48 partitions passed across net472 and net8.0 on both Windows and Linux. That was in April, against a `develop` that has since diverged, so it wants re-establishing here.

The failures that actually blocked #716 were never about the JDK: the `lld` toolchain drift, the MSBuild 18 mismatch, and the flake tail, all now fixed on `main`.

Supersedes #716.
