### PR TITLE
Fix four sources of CI failure

### DIFF
--- a/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
+++ b/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
@@ -3617,7 +3617,7 @@ java/awt/Focus/ModalDialogInitialFocusTest/ModalDialogInitialFocusTest.html     
 java/awt/Focus/ModalExcludedWindowClickTest/ModalExcludedWindowClickTest.html                                           macosx-all
 java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.html                                       linux-all,macosx-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.html                                           macosx-all
-java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.html                                           macosx-all
+java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.html                                           macosx-all,windows-all
 java/awt/font/GlyphVector/TestLayoutFlags.java                                                                          macosx-all
 java/awt/font/Underline/UnderlineTest.java                                                                              macosx-all
 java/awt/FontClass/HeadlessFont.java                                                                                    macosx-all
@@ -4259,7 +4259,7 @@ java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.jav
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java                                           macosx-all
 java/awt/Focus/ToFrontFocusTest/ToFrontFocus.java                                                                       generic-all
 java/awt/Focus/WindowInitialFocusTest/WindowInitialFocusTest.java                                                       generic-all
-java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java                                           macosx-all
+java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java                                           macosx-all,windows-all
 java/awt/FontClass/CreateFont/bigfont.java                                                                              generic-all
 java/awt/Frame/DisposeStressTest/DisposeStressTest.java                                                                 generic-all
 java/awt/Frame/NonEDT_GUI_DeadlockTest/NonEDT_GUI_Deadlock.java                                                         macosx-all
@@ -4315,3 +4315,14 @@ java/awt/Focus/6401036/InputVerifierTest2.java                                  
 javax/swing/DefaultButtonModel/DefaultButtonModelCrashTest.java                                                         generic-all
 javax/swing/JFileChooser/FileSystemView/Win32FolderSort.java                                                            generic-all
 lib/property/CheckWindowsProperty.java                                                                                  generic-all
+
+# SetFullScreenTest arrived with jdk8u504-b01; it does not exist in 8u482. It
+# goes full screen, then asks Robot for the colour of the centre pixel and
+# expects the red frame it just showed. On the runner it reads 12,12,12, the
+# desktop background, 300ms after waitForIdle. Every other test in
+# java/awt/FullScreen is already excluded for the same reason: a runner with no
+# interactive desktop session does not put a window on screen the way a real
+# one does. It failed on net472 win-x64 and passed elsewhere in the same run,
+# so it is intermittent rather than broken, but it is intermittent for the
+# reason its whole directory is excluded.
+java/awt/FullScreen/SetFullScreenTest.java                                                                              generic-all

--- a/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
+++ b/src/IKVM.OpenJDK.Tests/jdk/test/ExcludeList.txt
@@ -4326,3 +4326,13 @@ lib/property/CheckWindowsProperty.java                                          
 # so it is intermittent rather than broken, but it is intermittent for the
 # reason its whole directory is excluded.
 java/awt/FullScreen/SetFullScreenTest.java                                                                              generic-all
+
+# VerifyCACerts checks every root in the shipped cacerts bundle and errors on
+# any that expires within 90 days. "entrustevca [jdk]" expires 2026-11-27
+# 20:53:42 UTC, so the check began failing at 2026-08-29 20:53:42 UTC and fails
+# on every run from then on, on all platforms at once. It is not intermittent:
+# a run of partition 13 that finished before that instant passed and the next
+# one failed. The real fix is upstream refreshing the bundle, which jdk8u does
+# periodically; drop this entry when the next update removes or replaces that
+# root, rather than leaving it excluded indefinitely.
+sun/security/lib/cacerts/VerifyCACerts.java                                                                             generic-all

--- a/src/IKVM.Tests.Util/DotNetSdkResolver.cs
+++ b/src/IKVM.Tests.Util/DotNetSdkResolver.cs
@@ -15,9 +15,33 @@ namespace IKVM.Tests.Util
     public static class DotNetSdkResolver
     {
 
+        /// <summary>
+        /// Cache of previously resolved base paths, keyed by the 'dotnet' executable they were resolved from. The
+        /// installed SDK cannot change while the test run is in progress, and the callers are test initializers that
+        /// ask for the same path over and over, so the 'dotnet --info' process is only worth running once.
+        /// </summary>
+        static readonly Dictionary<string, string> cache = new Dictionary<string, string>();
+
         public static string ResolvePath(string dotnetExePath)
         {
-            var output = GetInfo(dotnetExePath ?? "dotnet");
+            var key = dotnetExePath ?? "dotnet";
+
+            // the lock also keeps concurrent tests from spawning 'dotnet --info' at the same time, which is part of
+            // what made the call slow enough to time out on a loaded machine in the first place
+            lock (cache)
+            {
+                if (cache.TryGetValue(key, out var cached))
+                    return cached;
+
+                var path = ResolvePathCore(key);
+                cache[key] = path;
+                return path;
+            }
+        }
+
+        static string ResolvePathCore(string dotnetExePath)
+        {
+            var output = GetInfo(dotnetExePath);
             if (output == null || output.Count == 0)
                 return null;
 
@@ -47,12 +71,15 @@ namespace IKVM.Tests.Util
                 ["MSBuildExtensionsPath"] = null,
             };
 
+            // 'dotnet --info' enumerates every installed SDK and runtime, and CI runners have several of each and are
+            // busy running tests besides. A short budget here does not fail the call, it kills the process and throws
+            // OperationCanceledException out of whichever test initializer happened to ask, so give it room.
             var info = new List<string>();
             var task = (Cli.Wrap(dotnetExePath)
                 .WithArguments("--info")
                 .WithEnvironmentVariables(envv)
                 | info.Add)
-                .ExecuteAsync(new CancellationTokenSource(2000).Token);
+                .ExecuteAsync(new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
             task.GetAwaiter().GetResult();
 
             return info;

--- a/src/IKVM.Tests/Java/java/nio/channels/ServerSocketChannelTests.cs
+++ b/src/IKVM.Tests/Java/java/nio/channels/ServerSocketChannelTests.cs
@@ -66,15 +66,18 @@ namespace IKVM.Tests.Java.java.nio.channels
             var cancellationTokenSource = new CancellationTokenSource();
             var receive = ByteBuffer.allocate(sizeof(int) * 4);
 
+            // bind on the test thread rather than inside the server task: port 0 asks the OS for a
+            // free port instead of claiming a fixed one that something else on the machine may hold,
+            // and returning from bind establishes the listen backlog, so the client below can connect
+            // immediately instead of sleeping and hoping the task got there first
+            using var server = ServerSocketChannel.open();
+            server.bind(new InetSocketAddress(0));
+            server.configureBlocking(true);
+            var port = server.socket().getLocalPort();
+
             // server receives messages until cancelled
             var serverTask = Task.Run(() =>
             {
-                // initialize server
-                using var server = ServerSocketChannel.open();
-                var serverAddr = new InetSocketAddress(42341);
-                server.bind(serverAddr);
-                server.configureBlocking(true);
-
                 // accept the first socket
                 var c = server.accept();
 
@@ -83,9 +86,8 @@ namespace IKVM.Tests.Java.java.nio.channels
                     continue;
             });
 
-            // wait a second and write some messages to the server
-            await Task.Delay(1000);
-            using (var c = SocketChannel.open(new InetSocketAddress("127.0.0.1", 42341)))
+            // write some messages to the server
+            using (var c = SocketChannel.open(new InetSocketAddress("127.0.0.1", port)))
             {
                 foreach (var i in new[] { 1, 2, 3, 4 })
                 {
@@ -120,18 +122,18 @@ namespace IKVM.Tests.Java.java.nio.channels
         {
             var cancellationTokenSource = new CancellationTokenSource();
             var receive = ByteBuffer.allocate(sizeof(int) * 4);
-            int port = 0;
+
+            // bind on the test thread rather than inside the server task. The port was previously
+            // read back from a field the task assigned, a second after starting it, so a task that
+            // had not been scheduled yet left the client connecting to port 0
+            using var server = ServerSocketChannel.open();
+            server.bind(new InetSocketAddress(0));
+            server.configureBlocking(false);
+            var port = server.socket().getLocalPort();
 
             // server receives messages until cancelled
             var serverTask = Task.Run(() =>
             {
-                // initialize server
-                using var server = ServerSocketChannel.open();
-                var serverAddr = new InetSocketAddress(port);
-                server.bind(serverAddr);
-                server.configureBlocking(false);
-                port = server.socket().getLocalPort();
-
                 // begin selector
                 var selector = Selector.open();
                 var serverKey = server.register(selector, server.validOps(), null);


### PR DESCRIPTION
Four causes. Three are intermittent; one is not, and is currently keeping `main` red regardless of this PR.

### VerifyCACerts — not a flake, fails from here on

`sun/security/lib/cacerts/VerifyCACerts.java` errors on any root within 90 days of expiry:

```
ERROR: cert "entrustevca [jdk]" expiry "Fri Nov 27 20:53:42 UTC 2026" will expire within 90 days
```

The window opened at **2026-08-29 20:53:42 UTC**. The two CI runs on this branch bracket that instant: partition 13 `net472:win-x64` ran 17:34–18:46 UTC and passed; the next run crossed it and failed on `net472:win-x64` and `net8.0:linux-x64` together. Every run fails from here, on every platform and branch, until the bundle changes. Excluded `generic-all`, with the comment saying to drop the entry when jdk8u next refreshes cacerts rather than leaving it in indefinitely.

### `dotnet --info`

`DotNetSdkResolver.GetInfo` gave the process a 2000ms cancellation token, and `ResolvePath` was uncached, so every test initializer in the five projects that ask for reference assembly paths respawned it, several concurrently, on a machine already running the tests. When it missed the deadline CliWrap killed the process and the `OperationCanceledException` surfaced out of `TestInitialize`. Seen on `main` (net8.0 win-x86), `docs/claude-md` (net8.0 win-x64) and `test/reenable-passing`. Cached, and given two minutes.

### ServerSocketChannel tests

`CanReceiveBlocking` bound a fixed port 42341, which anything else on the machine — including the previous run's socket in TIME_WAIT — can be holding. `CanReceiveNonBlocking` asked for an ephemeral port correctly but read it back out of a variable the server task assigns, one second after starting the task, so a task not yet scheduled left the client connecting to port 0. Both now bind on the test thread before the task starts.

### Two AWT tests

`WindowUpdateFocusabilityTest` was already excluded on macOS and failed twice on Windows with `window1 is not focusable`. Widened to `macosx-all,windows-all`; not seen on Linux, so the scope stops there, and the `.html` and `.java` halves move together.

`SetFullScreenTest` does not exist in 8u482 and arrived with jdk8u504-b01 — a fourth test from that upgrade needing an exclusion, missed because it fails intermittently rather than every time. It Robot-samples the centre pixel expecting red and read 12,12,12, the desktop background. Every other test in `java/awt/FullScreen` is already excluded for that reason.

Scopes were checked against `RegressionParameters.getPlatforms`, which builds `os.family + "-all"`, and `ExcludeList.readBugIds`, which comma-splits the second column.

### Not addressed

- `URLTests.CanGetFromURL` makes seven live HTTPS requests to badssl.com and has failed three times, including on `main`. Left alone deliberately; replacing that dependency is a separate decision.
- A long tail of one-off graphical failures remains — the two runs on this branch turned up five more, all distinct, none repeating: `ButtonGroupLayoutTraversalTest`, `SetLocationRelativeToTest`, `ConsumeNextMnemonicKeyTypedTest`, `TestGCMKeyAndIvCheck`, `TransformationWarningsTest`. At 48 OpenJDK jobs per run, retiring these one occurrence at a time will not converge.
- `LegacyDHEKeyExchange`, one occurrence on 15 August. Not graphical; left as evidence.
- A truncated SDK download from the aka.ms CDN failed `IKVM.Tests:net8.0:win-x86` on 29 August. No change: retrying the step papers over it rather than fixing anything.
- `develop` fails to build because `IKVM.slnx:90` is the only `.ikvmproj` entry without a `Type` GUID. `main` has no `IKVM.slnx`.
